### PR TITLE
Implement login and reigstration on frontend, API improvements and fixes

### DIFF
--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@mui/icons-material": "^5.4.2",
+        "@mui/lab": "^5.0.0-alpha.71",
         "@mui/material": "^5.4.1",
         "@octokit/rest": "^18.12.0",
         "@testing-library/user-event": "^13.5.0",
@@ -1883,6 +1884,75 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
       "integrity": "sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg=="
     },
+    "node_modules/@date-io/core": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.13.1.tgz",
+      "integrity": "sha512-pVI9nfkf2qClb2Cxdq0Q4zJhdawMG4ybWZUVGifT78FDwzRMX2SwXBb55s5NRJk0HcIicDuxktmCtemZqMH1Zg=="
+    },
+    "node_modules/@date-io/date-fns": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.13.1.tgz",
+      "integrity": "sha512-8fmfwjiLMpFLD+t4NBwDx0eblWnNcgt4NgfT/uiiQTGI81fnPu9tpBMYdAcuWxaV7LLpXgzLBx1SYWAMDVUDQQ==",
+      "dependencies": {
+        "@date-io/core": "^2.13.1"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@date-io/dayjs": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.13.1.tgz",
+      "integrity": "sha512-5bL4WWWmlI4uGZVScANhHJV7Mjp93ec2gNeUHDqqLaMZhp51S0NgD25oqj/k0LqBn1cdU2MvzNpk/ObMmVv5cQ==",
+      "dependencies": {
+        "@date-io/core": "^2.13.1"
+      },
+      "peerDependencies": {
+        "dayjs": "^1.8.17"
+      },
+      "peerDependenciesMeta": {
+        "dayjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@date-io/luxon": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.13.1.tgz",
+      "integrity": "sha512-yG+uM7lXfwLyKKEwjvP8oZ7qblpmfl9gxQYae55ifbwiTs0CoCTkYkxEaQHGkYtTqGTzLqcb0O9Pzx6vgWg+yg==",
+      "dependencies": {
+        "@date-io/core": "^2.13.1"
+      },
+      "peerDependencies": {
+        "luxon": "^1.21.3 || ^2.x"
+      },
+      "peerDependenciesMeta": {
+        "luxon": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@date-io/moment": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.13.1.tgz",
+      "integrity": "sha512-XX1X/Tlvl3TdqQy2j0ZUtEJV6Rl8tOyc5WOS3ki52He28Uzme4Ro/JuPWTMBDH63weSWIZDlbR7zBgp3ZA2y1A==",
+      "dependencies": {
+        "@date-io/core": "^2.13.1"
+      },
+      "peerDependencies": {
+        "moment": "^2.24.0"
+      },
+      "peerDependenciesMeta": {
+        "moment": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.7.2",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
@@ -1959,9 +2029,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.1.tgz",
-      "integrity": "sha512-bW1Tos67CZkOURLc0OalnfxtSXQJMrAMV0jZTVGJUPSOd4qgjF3+tTD5CwJM13PHA8cltGW1WGbbvV9NpvUZPw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
       "dependencies": {
         "@emotion/memoize": "^0.7.4"
       }
@@ -2853,6 +2923,91 @@
         }
       }
     },
+    "node_modules/@mui/lab": {
+      "version": "5.0.0-alpha.71",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.71.tgz",
+      "integrity": "sha512-ScGfSsiYa2XZl+TYEgDFoCv1DoXoWNQwyJBbDlapacEw10wGmY6sgMkCjsPhpuabgC5FVOaV5k30OxG7cZKXJQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@date-io/date-fns": "^2.13.1",
+        "@date-io/dayjs": "^2.13.1",
+        "@date-io/luxon": "^2.13.1",
+        "@date-io/moment": "^2.13.1",
+        "@mui/base": "5.0.0-alpha.70",
+        "@mui/system": "^5.4.4",
+        "@mui/utils": "^5.4.4",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2",
+        "react-transition-group": "^4.4.2",
+        "rifm": "^0.12.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "date-fns": "^2.25.0",
+        "dayjs": "^1.10.7",
+        "luxon": "^1.28.0 || ^2.0.0",
+        "moment": "^2.29.1",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab/node_modules/@mui/base": {
+      "version": "5.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.70.tgz",
+      "integrity": "sha512-8UZWhz1JYuQnPkAbC37cl4aL1JyNWZ08wDXlp57W7fYQp5xFpBP/7p56AcWg2qG9CNJP0IlFg2Wp4md1v2l4iA==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@emotion/is-prop-valid": "^1.1.2",
+        "@mui/utils": "^5.4.4",
+        "@popperjs/core": "^2.4.4",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.4.1.tgz",
@@ -2898,12 +3053,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.4.1.tgz",
-      "integrity": "sha512-Xbc4MXFZxv0A3hoc4TSDBhzjhstppKfc+gQcTMqqBZQP7KjnmxF+wO7rEPQuYRBihjCqQBdrHIGMLsKWrhkZkQ==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.4.4.tgz",
+      "integrity": "sha512-V/gxttr6736yJoU9q+4xxXsa0K/w9Hn9pg99zsOHt7i/O904w2CX5NHh5WqDXtoUzVcayLF0RB17yr6l79CE+A==",
       "dependencies": {
-        "@babel/runtime": "^7.17.0",
-        "@mui/utils": "^5.4.1",
+        "@babel/runtime": "^7.17.2",
+        "@mui/utils": "^5.4.4",
         "prop-types": "^15.7.2"
       },
       "engines": {
@@ -2924,11 +3079,11 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.4.1.tgz",
-      "integrity": "sha512-CFLNJkopRoAuShkgUZOTBVxdTlKu4w6L4kOwPi4r3QB2XXS6O5kyLHSsg9huUbtOYk5Dv5UZyUSc5pw4J7ezdg==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.4.4.tgz",
+      "integrity": "sha512-AKx3rSgB6dmt5f7iP4K18mLFlE5/9EfJe/5EH9Pyqez8J/CPkTgYhJ/Va6qtlrcunzpui+uG/vfuf04yAZekSg==",
       "dependencies": {
-        "@babel/runtime": "^7.17.0",
+        "@babel/runtime": "^7.17.2",
         "@emotion/cache": "^11.7.1",
         "prop-types": "^15.7.2"
       },
@@ -2954,15 +3109,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.4.1.tgz",
-      "integrity": "sha512-07JBYf9iQdxIHZU8cFOLoxBnkQDUPLb7UBhNxo4998yEqpWFJ00WKgEVYBKvPl0X+MRU/20wqFz6yGIuCx4AeA==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.4.4.tgz",
+      "integrity": "sha512-Zjbztq2o/VRuRRCWjG44juRrPKYLQMqtQpMHmMttGu5BnvK6PAPW3WOY0r1JCAwLhbd8Kug9nyhGQYKETjo+tQ==",
       "dependencies": {
-        "@babel/runtime": "^7.17.0",
-        "@mui/private-theming": "^5.4.1",
-        "@mui/styled-engine": "^5.4.1",
-        "@mui/types": "^7.1.1",
-        "@mui/utils": "^5.4.1",
+        "@babel/runtime": "^7.17.2",
+        "@mui/private-theming": "^5.4.4",
+        "@mui/styled-engine": "^5.4.4",
+        "@mui/types": "^7.1.2",
+        "@mui/utils": "^5.4.4",
         "clsx": "^1.1.1",
         "csstype": "^3.0.10",
         "prop-types": "^15.7.2"
@@ -2993,9 +3148,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.1.tgz",
-      "integrity": "sha512-33hbHFLCwenTpS+T4m4Cz7cQ/ng5g+IgtINkw1uDBVvi1oM83VNt/IGzWIQNPK8H2pr0WIfkmboD501bVdYsPw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.2.tgz",
+      "integrity": "sha512-SD7O1nVzqG+ckQpFjDhXPZjRceB8HQFHEvdLLrPhlJy4lLbwEBbxK74Tj4t6Jgk0fTvLJisuwOutrtYe9P/xBQ==",
       "peerDependencies": {
         "@types/react": "*"
       },
@@ -3006,11 +3161,11 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.4.1.tgz",
-      "integrity": "sha512-5HzM+ZjlQqbSp7UTOvLlhAjkWB+o9Z4NzO0W+yhZ1KnxITr+zr/MBzYmmQ3kyvhui8pyhgRDoTcVgwb+02ZUZA==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.4.4.tgz",
+      "integrity": "sha512-hfYIXEuhc2mXMGN5nUPis8beH6uE/zl3uMWJcyHX0/LN/+QxO9zhYuV6l8AsAaphHFyS/fBv0SW3Nid7jw5hKQ==",
       "dependencies": {
-        "@babel/runtime": "^7.17.0",
+        "@babel/runtime": "^7.17.2",
         "@types/prop-types": "^15.7.4",
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.7.2",
@@ -14580,6 +14735,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rifm": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/rifm/-/rifm-0.12.1.tgz",
+      "integrity": "sha512-OGA1Bitg/dSJtI/c4dh90svzaUPt228kzFsUkJbtA2c964IqEAwWXeL9ZJi86xWv3j5SMqRvGULl7bA6cK0Bvg==",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -18477,6 +18640,43 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
       "integrity": "sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg=="
     },
+    "@date-io/core": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.13.1.tgz",
+      "integrity": "sha512-pVI9nfkf2qClb2Cxdq0Q4zJhdawMG4ybWZUVGifT78FDwzRMX2SwXBb55s5NRJk0HcIicDuxktmCtemZqMH1Zg=="
+    },
+    "@date-io/date-fns": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.13.1.tgz",
+      "integrity": "sha512-8fmfwjiLMpFLD+t4NBwDx0eblWnNcgt4NgfT/uiiQTGI81fnPu9tpBMYdAcuWxaV7LLpXgzLBx1SYWAMDVUDQQ==",
+      "requires": {
+        "@date-io/core": "^2.13.1"
+      }
+    },
+    "@date-io/dayjs": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.13.1.tgz",
+      "integrity": "sha512-5bL4WWWmlI4uGZVScANhHJV7Mjp93ec2gNeUHDqqLaMZhp51S0NgD25oqj/k0LqBn1cdU2MvzNpk/ObMmVv5cQ==",
+      "requires": {
+        "@date-io/core": "^2.13.1"
+      }
+    },
+    "@date-io/luxon": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.13.1.tgz",
+      "integrity": "sha512-yG+uM7lXfwLyKKEwjvP8oZ7qblpmfl9gxQYae55ifbwiTs0CoCTkYkxEaQHGkYtTqGTzLqcb0O9Pzx6vgWg+yg==",
+      "requires": {
+        "@date-io/core": "^2.13.1"
+      }
+    },
+    "@date-io/moment": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.13.1.tgz",
+      "integrity": "sha512-XX1X/Tlvl3TdqQy2j0ZUtEJV6Rl8tOyc5WOS3ki52He28Uzme4Ro/JuPWTMBDH63weSWIZDlbR7zBgp3ZA2y1A==",
+      "requires": {
+        "@date-io/core": "^2.13.1"
+      }
+    },
     "@emotion/babel-plugin": {
       "version": "11.7.2",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
@@ -18543,9 +18743,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.1.tgz",
-      "integrity": "sha512-bW1Tos67CZkOURLc0OalnfxtSXQJMrAMV0jZTVGJUPSOd4qgjF3+tTD5CwJM13PHA8cltGW1WGbbvV9NpvUZPw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
       "requires": {
         "@emotion/memoize": "^0.7.4"
       }
@@ -19183,6 +19383,42 @@
         "@babel/runtime": "^7.17.0"
       }
     },
+    "@mui/lab": {
+      "version": "5.0.0-alpha.71",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.71.tgz",
+      "integrity": "sha512-ScGfSsiYa2XZl+TYEgDFoCv1DoXoWNQwyJBbDlapacEw10wGmY6sgMkCjsPhpuabgC5FVOaV5k30OxG7cZKXJQ==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@date-io/date-fns": "^2.13.1",
+        "@date-io/dayjs": "^2.13.1",
+        "@date-io/luxon": "^2.13.1",
+        "@date-io/moment": "^2.13.1",
+        "@mui/base": "5.0.0-alpha.70",
+        "@mui/system": "^5.4.4",
+        "@mui/utils": "^5.4.4",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2",
+        "react-transition-group": "^4.4.2",
+        "rifm": "^0.12.1"
+      },
+      "dependencies": {
+        "@mui/base": {
+          "version": "5.0.0-alpha.70",
+          "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.70.tgz",
+          "integrity": "sha512-8UZWhz1JYuQnPkAbC37cl4aL1JyNWZ08wDXlp57W7fYQp5xFpBP/7p56AcWg2qG9CNJP0IlFg2Wp4md1v2l4iA==",
+          "requires": {
+            "@babel/runtime": "^7.17.2",
+            "@emotion/is-prop-valid": "^1.1.2",
+            "@mui/utils": "^5.4.4",
+            "@popperjs/core": "^2.4.4",
+            "clsx": "^1.1.1",
+            "prop-types": "^15.7.2",
+            "react-is": "^17.0.2"
+          }
+        }
+      }
+    },
     "@mui/material": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.4.1.tgz",
@@ -19203,52 +19439,52 @@
       }
     },
     "@mui/private-theming": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.4.1.tgz",
-      "integrity": "sha512-Xbc4MXFZxv0A3hoc4TSDBhzjhstppKfc+gQcTMqqBZQP7KjnmxF+wO7rEPQuYRBihjCqQBdrHIGMLsKWrhkZkQ==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.4.4.tgz",
+      "integrity": "sha512-V/gxttr6736yJoU9q+4xxXsa0K/w9Hn9pg99zsOHt7i/O904w2CX5NHh5WqDXtoUzVcayLF0RB17yr6l79CE+A==",
       "requires": {
-        "@babel/runtime": "^7.17.0",
-        "@mui/utils": "^5.4.1",
+        "@babel/runtime": "^7.17.2",
+        "@mui/utils": "^5.4.4",
         "prop-types": "^15.7.2"
       }
     },
     "@mui/styled-engine": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.4.1.tgz",
-      "integrity": "sha512-CFLNJkopRoAuShkgUZOTBVxdTlKu4w6L4kOwPi4r3QB2XXS6O5kyLHSsg9huUbtOYk5Dv5UZyUSc5pw4J7ezdg==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.4.4.tgz",
+      "integrity": "sha512-AKx3rSgB6dmt5f7iP4K18mLFlE5/9EfJe/5EH9Pyqez8J/CPkTgYhJ/Va6qtlrcunzpui+uG/vfuf04yAZekSg==",
       "requires": {
-        "@babel/runtime": "^7.17.0",
+        "@babel/runtime": "^7.17.2",
         "@emotion/cache": "^11.7.1",
         "prop-types": "^15.7.2"
       }
     },
     "@mui/system": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.4.1.tgz",
-      "integrity": "sha512-07JBYf9iQdxIHZU8cFOLoxBnkQDUPLb7UBhNxo4998yEqpWFJ00WKgEVYBKvPl0X+MRU/20wqFz6yGIuCx4AeA==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.4.4.tgz",
+      "integrity": "sha512-Zjbztq2o/VRuRRCWjG44juRrPKYLQMqtQpMHmMttGu5BnvK6PAPW3WOY0r1JCAwLhbd8Kug9nyhGQYKETjo+tQ==",
       "requires": {
-        "@babel/runtime": "^7.17.0",
-        "@mui/private-theming": "^5.4.1",
-        "@mui/styled-engine": "^5.4.1",
-        "@mui/types": "^7.1.1",
-        "@mui/utils": "^5.4.1",
+        "@babel/runtime": "^7.17.2",
+        "@mui/private-theming": "^5.4.4",
+        "@mui/styled-engine": "^5.4.4",
+        "@mui/types": "^7.1.2",
+        "@mui/utils": "^5.4.4",
         "clsx": "^1.1.1",
         "csstype": "^3.0.10",
         "prop-types": "^15.7.2"
       }
     },
     "@mui/types": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.1.tgz",
-      "integrity": "sha512-33hbHFLCwenTpS+T4m4Cz7cQ/ng5g+IgtINkw1uDBVvi1oM83VNt/IGzWIQNPK8H2pr0WIfkmboD501bVdYsPw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.2.tgz",
+      "integrity": "sha512-SD7O1nVzqG+ckQpFjDhXPZjRceB8HQFHEvdLLrPhlJy4lLbwEBbxK74Tj4t6Jgk0fTvLJisuwOutrtYe9P/xBQ==",
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.4.1.tgz",
-      "integrity": "sha512-5HzM+ZjlQqbSp7UTOvLlhAjkWB+o9Z4NzO0W+yhZ1KnxITr+zr/MBzYmmQ3kyvhui8pyhgRDoTcVgwb+02ZUZA==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.4.4.tgz",
+      "integrity": "sha512-hfYIXEuhc2mXMGN5nUPis8beH6uE/zl3uMWJcyHX0/LN/+QxO9zhYuV6l8AsAaphHFyS/fBv0SW3Nid7jw5hKQ==",
       "requires": {
-        "@babel/runtime": "^7.17.0",
+        "@babel/runtime": "^7.17.2",
         "@types/prop-types": "^15.7.4",
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.7.2",
@@ -27674,6 +27910,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "rifm": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/rifm/-/rifm-0.12.1.tgz",
+      "integrity": "sha512-OGA1Bitg/dSJtI/c4dh90svzaUPt228kzFsUkJbtA2c964IqEAwWXeL9ZJi86xWv3j5SMqRvGULl7bA6cK0Bvg==",
+      "requires": {}
     },
     "rimraf": {
       "version": "3.0.2",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -6,6 +6,7 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^5.4.2",
+    "@mui/lab": "^5.0.0-alpha.71",
     "@mui/material": "^5.4.1",
     "@octokit/rest": "^18.12.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1,14 +1,26 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Author from "./api/models/Author";
 import Homepage from "./pages/Homepage";
 import Mainpage from "./pages/Mainpage";
 import Profile from "./pages/Profile";
 import ErrorPage from "./pages/Error";
+import api from "./api/api";
 
 function App() {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [currentUser, setCurrentUser] = useState<Author | undefined>(undefined);
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      api.authors
+        .getCurrent()
+        .then((author) => setCurrentUser(author))
+        .catch((error) => {
+          localStorage.removeItem("token");
+        });
+    }
+  }, []);
 
   return (
     <BrowserRouter>
@@ -16,7 +28,11 @@ function App() {
         <Route
           index
           element={
-            currentUser ? <Mainpage currentUser={currentUser} /> : <Homepage />
+            currentUser ? (
+              <Mainpage currentUser={currentUser} />
+            ) : (
+              <Homepage setCurrentUser={setCurrentUser} />
+            )
           }
         />
         <Route

--- a/src/app/src/api/api.ts
+++ b/src/app/src/api/api.ts
@@ -64,7 +64,7 @@ const api = {
      * @returns a list of authors
      */
     list: async (page?: number, size?: number): Promise<Author[]> =>
-      (await axios.get("/authors", { params: { page, size } })).data,
+      (await axios.get("/authors", { params: { page, size } })).data.items,
 
     /**
      * Gets data about the currently logged-in author.
@@ -106,7 +106,7 @@ const api = {
             await axios.get(`/authors/${authorId}/inbox`, {
               params: { page, size },
             })
-          ).data,
+          ).data.items,
 
         /**
          * Send a post to the author's inbox.
@@ -131,7 +131,7 @@ const api = {
          * Fetches a list of items the author has liked.
          */
         list: async (): Promise<(Post | Comment)[]> =>
-          (await axios.get(`/authors/${authorId}/likes`)).data,
+          (await axios.get(`/authors/${authorId}/likes`)).data.items,
       },
 
       /**
@@ -143,7 +143,7 @@ const api = {
          * @returns a list of the profiles of the followers
          */
         list: async (): Promise<Author[]> =>
-          axios.get(`/authors/${authorId}/followers`),
+          (await axios.get(`/authors/${authorId}/followers`)).data.items,
 
         /**
          * Actions on the existing or potential follower with ID `followerId` of the author.
@@ -190,7 +190,7 @@ const api = {
             await axios.get(`/authors/${authorId}/posts`, {
               params: { page, size },
             })
-          ).data,
+          ).data.items,
 
         /**
          * Creates a post with a random ID.
@@ -254,7 +254,7 @@ const api = {
              */
             list: async (): Promise<Like[]> =>
               (await axios.get(`/authors/${authorId}/posts/${postId}/likes`))
-                .data,
+                .data.items,
 
             /**
              * Like the post.
@@ -285,7 +285,7 @@ const api = {
                   `/authors/${authorId}/posts/${postId}/comments`,
                   { params: { page, size } }
                 )
-              ).data,
+              ).data.items,
 
             /**
              * Creates a comment on the post with a random ID.
@@ -317,7 +317,7 @@ const api = {
                     await axios.get(
                       `/authors/${authorId}/posts/${postId}/comments/${commentId}/likes`
                     )
-                  ).data,
+                  ).data.items,
 
                 /**
                  * Like the post.

--- a/src/app/src/api/api.ts
+++ b/src/app/src/api/api.ts
@@ -20,22 +20,30 @@ axios.interceptors.request.use((config) => {
 const api = {
   /**
    * Log into an existing author's account.
+   * @returns the author
    */
-  login: async (email: string, password: string) => {
+  login: async (email: string, password: string): Promise<Author> => {
     const result = await axios.post("/login", { email, password });
-    localStorage.setItem("token", result.data);
+    localStorage.setItem("token", result.data.token);
+    return result.data.author;
   },
 
   /**
    * Register and log into a new author's account.
+   * @returns the new author
    */
-  register: async (email: string, password: string, displayName: string) => {
+  register: async (
+    email: string,
+    password: string,
+    displayName: string
+  ): Promise<Author> => {
     const result = await axios.post("/register", {
       email,
       password,
       displayName,
     });
-    localStorage.setItem("token", result.data);
+    localStorage.setItem("token", result.data.token);
+    return result.data.author;
   },
 
   /**

--- a/src/app/src/api/api.ts
+++ b/src/app/src/api/api.ts
@@ -1,4 +1,4 @@
-import Axios, { AxiosResponse } from "axios";
+import Axios from "axios";
 import Author from "./models/Author";
 import Comment from "./models/Comment";
 import Like from "./models/Like";
@@ -12,7 +12,7 @@ axios.interceptors.request.use((config) => {
   config.headers = config.headers || {};
   const token = localStorage.getItem("token");
   if (token) {
-    config.headers.authorization = `Bearer ${token}`;
+    config.headers["Authorization"] = `Bearer ${token}`;
   }
   return config;
 });
@@ -55,8 +55,8 @@ const api = {
      * @param size the number of authors per page
      * @returns a list of authors
      */
-    list: async (page?: number, size?: number) =>
-      (await axios.get<Author[]>("/authors", { params: { page, size } })).data,
+    list: async (page?: number, size?: number): Promise<Author[]> =>
+      (await axios.get("/authors", { params: { page, size } })).data,
 
     /**
      * Actions on the author with ID `authorId`.
@@ -66,20 +66,16 @@ const api = {
        * Fetches the profile of the author.
        * @returns profile of the author
        */
-      get: async () => (await axios.get<Author>(`/authors/${authorId}`)).data,
+      get: async (): Promise<Author> =>
+        (await axios.get(`/authors/${authorId}`)).data,
 
       /**
        * Updates the profile of the author.
        * @param data the new profile data of the author
        * @returns TODO
        */
-      update: async (data: Author) =>
-        (
-          await axios.post<Author, AxiosResponse<unknown>>(
-            `/authors/${authorId}`,
-            data
-          )
-        ).data,
+      update: async (data: Author): Promise<unknown> =>
+        (await axios.post(`/authors/${authorId}`, data)).data,
 
       /**
        * Actions relating to the author's inbox.
@@ -91,9 +87,9 @@ const api = {
          * @param size the number of authors per page
          * @returns a list of posts in the inbox
          */
-        list: async (page?: number, size?: number) =>
+        list: async (page?: number, size?: number): Promise<Post[]> =>
           (
-            await axios.get<Post[]>(`/authors/${authorId}/inbox`, {
+            await axios.get(`/authors/${authorId}/inbox`, {
               params: { page, size },
             })
           ).data,
@@ -102,20 +98,15 @@ const api = {
          * Send a post to the author's inbox.
          * @returns TODO
          */
-        send: async (post: Post) =>
-          (
-            await axios.post<Post, AxiosResponse<unknown>>(
-              `/authors/${authorId}/inbox`,
-              post
-            )
-          ).data,
+        send: async (post: Post): Promise<unknown> =>
+          (await axios.post(`/authors/${authorId}/inbox`, post)).data,
 
         /**
          * Clear the author's inbox.
          * @returns TODO
          */
-        clear: async () =>
-          (await axios.delete<unknown>(`/authors/${authorId}/inbox`)).data,
+        clear: async (): Promise<unknown> =>
+          (await axios.delete(`/authors/${authorId}/inbox`)).data,
       },
 
       /**
@@ -125,9 +116,8 @@ const api = {
         /**
          * Fetches a list of items the author has liked.
          */
-        list: async () =>
-          (await axios.get<(Post | Comment)[]>(`/authors/${authorId}/likes`))
-            .data,
+        list: async (): Promise<(Post | Comment)[]> =>
+          (await axios.get(`/authors/${authorId}/likes`)).data,
       },
 
       /**
@@ -138,7 +128,8 @@ const api = {
          * Lists the followers of the author.
          * @returns a list of the profiles of the followers
          */
-        list: async () => axios.get<Author[]>(`/authors/${authorId}/followers`),
+        list: async (): Promise<Author[]> =>
+          axios.get(`/authors/${authorId}/followers`),
 
         /**
          * Actions on the existing or potential follower with ID `followerId` of the author.
@@ -148,32 +139,25 @@ const api = {
            * Checks if this author is in fact a follower.
            * @returns true if this author is a follower, false otherwise
            */
-          isAFollower: async () =>
-            (
-              await axios.get<boolean>(
-                `/authors/${authorId}/followers/${followerId}`
-              )
-            ).data,
+          isAFollower: async (): Promise<boolean> =>
+            (await axios.get(`/authors/${authorId}/followers/${followerId}`))
+              .data,
 
           /**
            * Makes this author a follower.
+           * @returns TODO
            */
-          follow: async () =>
-            (
-              await axios.put<void, AxiosResponse<unknown>>(
-                `/authors/${authorId}/followers/${followerId}`
-              )
-            ).data,
+          follow: async (): Promise<unknown> =>
+            (await axios.put(`/authors/${authorId}/followers/${followerId}`))
+              .data,
 
           /**
            * Makes this author not a follower.
+           * @returns TODO
            */
-          unfollow: async () =>
-            (
-              await axios.delete<void, AxiosResponse<unknown>>(
-                `/authors/${authorId}/followers/${followerId}`
-              )
-            ).data,
+          unfollow: async (): Promise<unknown> =>
+            (await axios.delete(`/authors/${authorId}/followers/${followerId}`))
+              .data,
         }),
       },
 
@@ -187,9 +171,9 @@ const api = {
          * @param size the number of posts per page
          * @returns a list of posts
          */
-        list: async (page?: number, size?: number) =>
+        list: async (page?: number, size?: number): Promise<Post[]> =>
           (
-            await axios.get<Post[]>(`/authors/${authorId}/posts`, {
+            await axios.get(`/authors/${authorId}/posts`, {
               params: { page, size },
             })
           ).data,
@@ -199,13 +183,8 @@ const api = {
          * @param data the data of the post
          * @returns TODO
          */
-        create: async (data: Omit<Post, "id">) =>
-          (
-            await axios.post<Omit<Post, "id">>(
-              `/authors/${authorId}/posts`,
-              data
-            )
-          ).data,
+        create: async (data: Omit<Post, "id">): Promise<unknown> =>
+          (await axios.post(`/authors/${authorId}/posts`, data)).data,
 
         /**
          * Actions on the post with ID `postId`.
@@ -215,57 +194,41 @@ const api = {
            * Fetches the post.
            * @returns the post
            */
-          get: async () =>
-            (await axios.get<Post>(`/authors/${authorId}/posts/${postId}`))
-              .data,
+          get: async (): Promise<Post> =>
+            (await axios.get(`/authors/${authorId}/posts/${postId}`)).data,
 
           /**
            * Updates the post with new data.
            * @param data the data to update the post with
            * @returns TODO
            */
-          update: async (data: Post) =>
-            (
-              await axios.post<Post, AxiosResponse<unknown>>(
-                `/authors/${authorId}/posts/${postId}`,
-                data
-              )
-            ).data,
+          update: async (data: Post): Promise<unknown> =>
+            (await axios.post(`/authors/${authorId}/posts/${postId}`, data))
+              .data,
 
           /**
            * Creates the post.
            * @param data the data of the post
            * @returns TODO
            */
-          create: async (data: Post) =>
-            (
-              await axios.put<Post, AxiosResponse<unknown>>(
-                `/authors/${authorId}/posts/${postId}`,
-                data
-              )
-            ).data,
+          create: async (data: Post): Promise<unknown> =>
+            (await axios.put(`/authors/${authorId}/posts/${postId}`, data))
+              .data,
 
           /**
            * Deletes the post.
            * @returns TODO
            */
-          delete: async () =>
-            (
-              await axios.delete<void, AxiosResponse<unknown>>(
-                `/authors/${authorId}/posts/${postId}`
-              )
-            ).data,
+          delete: async (): Promise<unknown> =>
+            (await axios.delete(`/authors/${authorId}/posts/${postId}`)).data,
 
           /**
            * Fetches the image of this post.
            * @returns the image of this post if it exists
            */
-          image: async () =>
-            (
-              await axios.get<Post>(
-                `/authors/${authorId}/posts/${postId}/image`
-              )
-            ).data,
+          image: async (): Promise<Post> =>
+            (await axios.get(`/authors/${authorId}/posts/${postId}/image`))
+              .data,
 
           /**
            * Actions relating to likes on the post.
@@ -275,19 +238,16 @@ const api = {
              * List the likes on this post.
              * @returns a list of the likes on the post
              */
-            list: async () =>
-              (
-                await axios.get<Like[]>(
-                  `/authors/${authorId}/posts/${postId}/likes`
-                )
-              ).data,
+            list: async (): Promise<Like[]> =>
+              (await axios.get(`/authors/${authorId}/posts/${postId}/likes`))
+                .data,
 
             /**
              * Like the post.
              * @returns TODO
              */
-            like: async () =>
-              await axios.post<Like, AxiosResponse<unknown>>(
+            like: async (): Promise<unknown> =>
+              await axios.post(
                 `/authors/${authorId}/inbox`,
                 (() => {
                   throw new Error("not implemented");
@@ -305,9 +265,9 @@ const api = {
              * @param size the number of comments per page
              * @returns a list of comments in the page
              */
-            list: async (page?: number, size?: number) =>
+            list: async (page?: number, size?: number): Promise<Comment[]> =>
               (
-                await axios.get<Comment[]>(
+                await axios.get(
                   `/authors/${authorId}/posts/${postId}/comments`,
                   { params: { page, size } }
                 )
@@ -318,9 +278,9 @@ const api = {
              * @param data the comment data
              * @returns TODO
              */
-            create: async (data: Omit<Comment, "id">) =>
+            create: async (data: Omit<Comment, "id">): Promise<unknown> =>
               (
-                await axios.post<Omit<Comment, "id">, AxiosResponse<unknown>>(
+                await axios.post(
                   `/authors/${authorId}/posts/${postId}/comments`,
                   data
                 )
@@ -338,9 +298,9 @@ const api = {
                  * List the likes on this post.
                  * @returns a list of the likes on the post
                  */
-                list: async () =>
+                list: async (): Promise<Like[]> =>
                   (
-                    await axios.get<Like[]>(
+                    await axios.get(
                       `/authors/${authorId}/posts/${postId}/comments/${commentId}/likes`
                     )
                   ).data,
@@ -349,8 +309,8 @@ const api = {
                  * Like the post.
                  * @returns TODO
                  */
-                like: async () =>
-                  await axios.post<Like, AxiosResponse<unknown>>(
+                like: async (): Promise<unknown> =>
+                  await axios.post(
                     `/authors/${authorId}/inbox`,
                     (() => {
                       throw new Error("not implemented");

--- a/src/app/src/api/api.ts
+++ b/src/app/src/api/api.ts
@@ -67,6 +67,12 @@ const api = {
       (await axios.get("/authors", { params: { page, size } })).data,
 
     /**
+     * Gets data about the currently logged-in author.
+     */
+    getCurrent: async (): Promise<Author> =>
+      (await axios.get("/authors/me")).data,
+
+    /**
      * Actions on the author with ID `authorId`.
      */
     withId: (authorId: string) => ({

--- a/src/app/src/pages/Homepage.tsx
+++ b/src/app/src/pages/Homepage.tsx
@@ -40,12 +40,12 @@ const ColorButton = Styled(Button)<ButtonProps>(({ theme }) => ({
 }));
 
 interface Props {
-  currentUser?: Author;
+  setCurrentUser: React.Dispatch<React.SetStateAction<Author | undefined>>;
 }
 
-export default function Homepage({ currentUser }: Props) {
+export default function Homepage({ setCurrentUser }: Props) {
   const [signUpScreen, setSignUpScreen] = useState(true);
-  const [signInScreen, setSignInScreen] = useState(false);
+  const [signInScreen, setSignInScreen] = useState(true);
   return (
     <HomeContainer>
       <LeftColumn>
@@ -54,21 +54,32 @@ export default function Homepage({ currentUser }: Props) {
       {!signUpScreen ? (
         <RightColumn>
           Welcome to a Modern Social Media Website.
-          <ColorButton variant="contained" onClick={() => setSignUpScreen(true)}>
+          <ColorButton
+            variant="contained"
+            onClick={() => setSignUpScreen(true)}
+          >
             Lets get started
           </ColorButton>
         </RightColumn>
       ) : signInScreen ? (
         <RightColumn>
-          <SignIn />
-          <Button sx={{ marginTop: '5%' }} variant="text" onClick={() => setSignInScreen(false)}>
+          <SignIn setCurrentUser={setCurrentUser} />
+          <Button
+            sx={{ marginTop: "5%" }}
+            variant="text"
+            onClick={() => setSignInScreen(false)}
+          >
             Sign up instead
           </Button>
         </RightColumn>
       ) : (
         <RightColumn>
-          <SignUp />
-          <Button sx={{ marginTop: '5%' }} variant="text" onClick={() => setSignInScreen(true)}>
+          <SignUp setCurrentUser={setCurrentUser} />
+          <Button
+            sx={{ marginTop: "5%" }}
+            variant="text"
+            onClick={() => setSignInScreen(true)}
+          >
             Sign in instead
           </Button>
         </RightColumn>

--- a/src/app/src/pages/SignIn.tsx
+++ b/src/app/src/pages/SignIn.tsx
@@ -1,73 +1,86 @@
 import TextField, { TextFieldProps } from '@mui/material/TextField';
-import Button, { ButtonProps } from '@mui/material/Button';
-import { styled as Styled } from '@mui/material/styles';
-import { useState } from 'react';
+import LoadingButton, { LoadingButtonProps } from "@mui/lab/LoadingButton";
+import { styled as Styled } from "@mui/material/styles";
+import { useState } from "react";
+import api from "../api/api";
+import Author from "../api/models/Author";
 
-const validate = (props: 'email' | 'password' | 'username', item: string) => {
-  if (props === 'username') {
-    if (item.length > 16) return false;
-    // fetch from database
+const validate = (props: "email" | "password", item: string) => {
+  if (props === "email") {
     return true;
   }
 
-  if (props === 'password') {
-    if (item.length > 16) return false;
-    // fetch from database
-    return true;
+  if (props === "password") {
+    return !!item;
   }
+
+  return false;
 };
 
-const ColorButton = Styled(Button)<ButtonProps>(({ theme }) => ({
-  color: theme.palette.getContrastText('#e6c9a8'),
-  padding: '10px',
-  marginTop: '2%',
-  backgroundColor: '#e6c9a8',
-  '&:hover': {
-    backgroundColor: '#D4AF85',
+const ColorButton = Styled(LoadingButton)<LoadingButtonProps>(({ theme }) => ({
+  color: theme.palette.getContrastText("#e6c9a8"),
+  padding: "10px",
+  marginTop: "2%",
+  backgroundColor: "#e6c9a8",
+  "&:hover": {
+    backgroundColor: "#D4AF85",
   },
 }));
 
 const TextFieldCustom = Styled(TextField)<TextFieldProps>(({ theme }) => ({
-  color: theme.palette.getContrastText('#fbf8f0'),
-  height: '50px',
-  padding: '10px',
-  '& .Mui-focused': {
-    color: 'black',
+  color: theme.palette.getContrastText("#fbf8f0"),
+  height: "50px",
+  padding: "10px",
+  "& .Mui-focused": {
+    color: "black",
   },
-  backgroundColor: 'white',
-  '&:hover': {
-    backgroundColor: '#fbf8f0',
+  backgroundColor: "white",
+  "&:hover": {
+    backgroundColor: "#fbf8f0",
   },
 }));
 
-export default function SignIn() {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [validUsername, setValidUsername] = useState(true);
+interface Props {
+  setCurrentUser: React.Dispatch<React.SetStateAction<Author | undefined>>;
+}
+
+export default function SignIn({ setCurrentUser }: Props) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [validEmail, setValidEmail] = useState(true);
   const [validPassword, setValidPassword] = useState(true);
+  const [isSigningIn, setIsSigningIn] = useState(false);
 
   const handleClick = () => {
-    validate('username', username) ? setValidUsername(true) : setValidUsername(false);
-    validate('password', password) ? setValidPassword(true) : setValidPassword(false);
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    validUsername && validPassword ? localStorage.setItem('user', username) : null;
-    //Discuss this^
+    setValidEmail(validate("email", email));
+    setValidPassword(validate("password", password));
+
+    if (validEmail && validPassword) {
+      setIsSigningIn(true);
+      api
+        .login(email, password)
+        .then((user) => setCurrentUser(user))
+        .catch((err) => console.log(err))
+        .finally(() => setIsSigningIn(false));
+    }
   };
-  const onChangeUsername = (event: any) => {
-    setUsername(event?.target?.value);
+
+  const onChangeEmail = (event: any) => {
+    setEmail(event?.target?.value);
   };
   const onChangePassword = (event: any) => {
     setPassword(event?.target?.value);
   };
+
   return (
     <>
-      {validUsername ? (
+      {validEmail ? (
         <TextFieldCustom
           id="standard-basic"
           color="primary"
-          label="Username"
+          label="Email"
           variant="standard"
-          onChange={onChangeUsername}
+          onChange={onChangeEmail}
         />
       ) : (
         <TextFieldCustom
@@ -75,8 +88,8 @@ export default function SignIn() {
           color="primary"
           label="Username"
           variant="standard"
-          onChange={onChangeUsername}
-          helperText="Incorrect username."
+          onChange={onChangeEmail}
+          helperText="Invalid email."
         />
       )}
       {validPassword ? (
@@ -99,7 +112,12 @@ export default function SignIn() {
           helperText="Incorrect password."
         />
       )}
-      <ColorButton variant="contained" onClick={handleClick}>
+      <ColorButton
+        variant="contained"
+        onClick={handleClick}
+        loading={isSigningIn}
+        disabled={isSigningIn}
+      >
         Sign in
       </ColorButton>
     </>

--- a/src/app/src/pages/__tests__/Homepage.test.tsx
+++ b/src/app/src/pages/__tests__/Homepage.test.tsx
@@ -22,7 +22,9 @@ afterEach(() => {
 
 describe('Homepage suite', () => {
   it('Renders correctly', () => {
-    const tree = renderer.create(<Homepage />).toJSON();
+    const tree = renderer
+      .create(<Homepage setCurrentUser={() => {}} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/src/app/src/pages/__tests__/SignIn.test.tsx
+++ b/src/app/src/pages/__tests__/SignIn.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 
 describe('SignUp suite', () => {
   it('Renders correctly', () => {
-    const tree = renderer.create(<SignIn />).toJSON();
+    const tree = renderer.create(<SignIn setCurrentUser={() => {}} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/src/app/src/pages/__tests__/SignUp.test.tsx
+++ b/src/app/src/pages/__tests__/SignUp.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 
 describe('SignUp suite', () => {
   it('Renders correctly', () => {
-    const tree = renderer.create(<SignUp />).toJSON();
+    const tree = renderer.create(<SignUp setCurrentUser={() => {}} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/src/app/src/pages/__tests__/__snapshots__/Homepage.test.tsx.snap
+++ b/src/app/src/pages/__tests__/__snapshots__/Homepage.test.tsx.snap
@@ -18,44 +18,7 @@ exports[`Homepage suite Renders correctly 1`] = `
     className="sc-hKwDye hFjOEP"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root css-1xkbzzz-MuiFormControl-root-MuiTextField-root"
-    >
-      <label
-        className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-root MuiFormLabel-colorPrimary css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
-        data-shrink={false}
-        htmlFor="standard-basic"
-        id="standard-basic-label"
-      >
-        Username
-      </label>
-      <div
-        className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1480iag-MuiInputBase-root-MuiInput-root"
-        onClick={[Function]}
-      >
-        <input
-          aria-describedby="standard-basic-helper-text"
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
-          disabled={false}
-          id="standard-basic"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          required={false}
-          type="text"
-        />
-      </div>
-      <p
-        className="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-1d1r5q-MuiFormHelperText-root"
-        id="standard-basic-helper-text"
-      >
-        Upto 16 characters.
-      </p>
-    </div>
-    <div
-      className="MuiFormControl-root MuiTextField-root css-1xkbzzz-MuiFormControl-root-MuiTextField-root"
+      className="MuiFormControl-root MuiTextField-root css-lxpoe1-MuiFormControl-root-MuiTextField-root"
     >
       <label
         className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-root MuiFormLabel-colorPrimary css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
@@ -73,7 +36,6 @@ exports[`Homepage suite Renders correctly 1`] = `
           aria-invalid={false}
           autoFocus={false}
           className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
-          defaultValue=""
           disabled={false}
           id="standard-basic"
           onAnimationStart={[Function]}
@@ -86,7 +48,7 @@ exports[`Homepage suite Renders correctly 1`] = `
       </div>
     </div>
     <div
-      className="MuiFormControl-root MuiTextField-root css-1xkbzzz-MuiFormControl-root-MuiTextField-root"
+      className="MuiFormControl-root MuiTextField-root css-lxpoe1-MuiFormControl-root-MuiTextField-root"
     >
       <label
         className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-root MuiFormLabel-colorPrimary css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
@@ -101,7 +63,6 @@ exports[`Homepage suite Renders correctly 1`] = `
         onClick={[Function]}
       >
         <input
-          aria-describedby="standard-basic-helper-text"
           aria-invalid={false}
           autoComplete="current-password"
           autoFocus={false}
@@ -116,15 +77,9 @@ exports[`Homepage suite Renders correctly 1`] = `
           type="password"
         />
       </div>
-      <p
-        className="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-1d1r5q-MuiFormHelperText-root"
-        id="standard-basic-helper-text"
-      >
-        Alphanumeric 16 characters.
-      </p>
     </div>
     <button
-      className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root css-1ohtnfp-MuiButtonBase-root-MuiButton-root"
+      className="MuiLoadingButton-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root css-abq3u9-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -142,7 +97,7 @@ exports[`Homepage suite Renders correctly 1`] = `
       tabIndex={0}
       type="button"
     >
-      Sign up
+      Sign in
     </button>
     <button
       className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root  css-1cgn1g0-MuiButtonBase-root-MuiButton-root"
@@ -163,7 +118,7 @@ exports[`Homepage suite Renders correctly 1`] = `
       tabIndex={0}
       type="button"
     >
-      Sign in instead
+      Sign up instead
     </button>
   </div>
 </div>

--- a/src/app/src/pages/__tests__/__snapshots__/SignIn.test.tsx.snap
+++ b/src/app/src/pages/__tests__/__snapshots__/SignIn.test.tsx.snap
@@ -11,7 +11,7 @@ Array [
       htmlFor="standard-basic"
       id="standard-basic-label"
     >
-      Username
+      Email
     </label>
     <div
       className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1480iag-MuiInputBase-root-MuiInput-root"
@@ -64,7 +64,7 @@ Array [
     </div>
   </div>,
   <button
-    className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root css-1ohtnfp-MuiButtonBase-root-MuiButton-root"
+    className="MuiLoadingButton-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root css-abq3u9-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}

--- a/src/app/src/pages/__tests__/__snapshots__/SignUp.test.tsx.snap
+++ b/src/app/src/pages/__tests__/__snapshots__/SignUp.test.tsx.snap
@@ -11,7 +11,7 @@ Array [
       htmlFor="standard-basic"
       id="standard-basic-label"
     >
-      Username
+      Display Name
     </label>
     <div
       className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1480iag-MuiInputBase-root-MuiInput-root"
@@ -109,7 +109,7 @@ Array [
     </p>
   </div>,
   <button
-    className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root css-1ohtnfp-MuiButtonBase-root-MuiButton-root"
+    className="MuiLoadingButton-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root css-abq3u9-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}

--- a/src/server/src/app.ts
+++ b/src/server/src/app.ts
@@ -4,7 +4,7 @@ import cors from 'cors';
 import path from 'path';
 import db from './db';
 
-import { authenticate, requiredLoggedIn } from './middlewares/auth.middlewares';
+import { authenticate } from './middlewares/auth.middlewares';
 
 import auth from './routes/auth.routes';
 import author from './routes/author.routes';
@@ -42,7 +42,7 @@ db.sync({ alter: true }).then(() => {
   }
 
   app.all('*', (req: Request, res: Response) => {
-    res.sendStatus(401);
+    res.status(404).send();
   });
 
   if (process.env.NODE_ENV !== 'test') {

--- a/src/server/src/controllers/auth.controllers.ts
+++ b/src/server/src/controllers/auth.controllers.ts
@@ -9,7 +9,8 @@ import { unauthorized } from '../handlers/auth.handlers';
 /**
  * Logs into an existing author's account.
  *
- * Responds with a JSON Web Token if successful, and an HTTP 400 otherwise.
+ * Responds with a JSON Web Token and author data if successful,
+ * and an HTTP 400 otherwise.
  */
 const login = async (req: Request, res: Response) => {
   const { email, password } = req.body;
@@ -41,8 +42,10 @@ const register = async (req: Request, res: Response) => {
       displayName,
     });
   } catch (e) {
-    console.error(e);
-    res.sendStatus(400);
+    const errorMessage = e.name === 'SequelizeUniqueConstraintError'
+      ? 'A user with that email already exists.'
+      : 'An unknown error occurred.';
+    res.status(400).json({ error: errorMessage });
     return;
   }
 

--- a/src/server/src/controllers/author.controllers.ts
+++ b/src/server/src/controllers/author.controllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import Author from '../models/Author';
+import { AuthenticatedRequest } from '../types/auth';
 import { PaginationRequest } from '../types/pagination';
 
 const getAllAuthors = async (req: PaginationRequest, res: Response) => {
@@ -22,7 +23,16 @@ const getAuthor = async (req: Request, res: Response) => {
     where: { id: req.params.id },
   });
   if (author === null) {
-    res.sendStatus(404);
+    res.status(404).send();
+    return;
+  }
+  res.send({ type: 'author', ...author.toJSON() });
+};
+
+const getCurrentAuthor = async (req: AuthenticatedRequest, res: Response) => {
+  const author = await Author.findOne({ where: { id: req.authorId } });
+  if (author === null) {
+    res.status(400).send();
     return;
   }
   res.send({ type: 'author', ...author.toJSON() });
@@ -51,4 +61,4 @@ const updateProfile = async (req: Request, res: Response) => {
   res.sendStatus(200);
 };
 
-export { getAllAuthors, getAuthor, updateProfile };
+export { getAllAuthors, getAuthor, getCurrentAuthor, updateProfile };

--- a/src/server/src/controllers/author.controllers.ts
+++ b/src/server/src/controllers/author.controllers.ts
@@ -42,7 +42,7 @@ const updateProfile = async (req: Request, res: Response) => {
   const { email, displayName, github, profileImage } = req.body;
   const author = await Author.findOne({ where: { id: req.params.id } });
   if (author === null) {
-    res.sendStatus(404);
+    res.status(404).send();
     return;
   }
 
@@ -58,7 +58,7 @@ const updateProfile = async (req: Request, res: Response) => {
     res.status(500).send(error);
     return;
   }
-  res.sendStatus(200);
+  res.status(200).send();
 };
 
 export { getAllAuthors, getAuthor, getCurrentAuthor, updateProfile };

--- a/src/server/src/controllers/post.controllers.ts
+++ b/src/server/src/controllers/post.controllers.ts
@@ -26,7 +26,7 @@ const createPost = async (req: AuthenticatedRequest, res: Response) => {
     },
   });
   if (author === null) {
-    res.sendStatus(404);
+    res.status(404).send();
     return;
   }
   try {
@@ -47,7 +47,7 @@ const createPost = async (req: AuthenticatedRequest, res: Response) => {
     return;
   }
 
-  res.sendStatus(200);
+  res.status(200).send();
 };
 
 const deleteAuthorPost = async (req: AuthenticatedRequest, res: Response) => {
@@ -56,7 +56,7 @@ const deleteAuthorPost = async (req: AuthenticatedRequest, res: Response) => {
     include: { model: Author, as: 'author' },
   });
   if (post === null) {
-    res.sendStatus(404);
+    res.status(404).send();
     return;
   }
   try {
@@ -66,7 +66,7 @@ const deleteAuthorPost = async (req: AuthenticatedRequest, res: Response) => {
     res.status(500).send({ error: error });
     return;
   }
-  res.sendStatus(200);
+  res.status(200).send();
 };
 
 const getAuthorPost = async (req: Request, res: Response) => {
@@ -96,7 +96,7 @@ const getAuthorPost = async (req: Request, res: Response) => {
     },
   });
   if (post === null) {
-    res.sendStatus(404);
+    res.status(404).send();
     return;
   }
   res.send({
@@ -150,7 +150,7 @@ const updateAuthorPost = async (req: AuthenticatedRequest, res: Response) => {
     where: { id: req.params.post_id, author_id: req.params.id },
   });
   if (post === null) {
-    res.sendStatus(404);
+    res.status(404).send();
     return;
   }
   const {
@@ -180,7 +180,7 @@ const updateAuthorPost = async (req: AuthenticatedRequest, res: Response) => {
     res.status(500).send({ error: error });
     return;
   }
-  res.sendStatus(200);
+  res.status(200).send();
 };
 
 export {

--- a/src/server/src/handlers/auth.handlers.ts
+++ b/src/server/src/handlers/auth.handlers.ts
@@ -14,14 +14,14 @@ const loginUser = async (
     unauthorized(res);
     return;
   }
-  const payload: JwtPayload = { authorId: author.id };
+  const payload: JwtPayload = { authorId: author.id.toString() };
   const token = jwt.sign(payload, process.env.JWT_SECRET);
-  res.send(token);
+  res.json({ token, author });
 };
 
 const unauthorized = (res: Response): void => {
   res.setHeader('WWW-Authenticate', 'Bearer');
-  res.sendStatus(401);
+  res.status(401).send();
 };
 
 export { loginUser, unauthorized };

--- a/src/server/src/routes/author.routes.ts
+++ b/src/server/src/routes/author.routes.ts
@@ -2,6 +2,7 @@ import { body, param } from 'express-validator';
 import express from 'express';
 const router = express.Router();
 
+import { requiredLoggedIn } from '../middlewares/auth.middlewares';
 import { paginate } from '../middlewares/pagination.middlewares';
 import { validate } from '../middlewares/validator.middlewares';
 
@@ -10,12 +11,14 @@ import posts from './post.routes';
 import {
   getAllAuthors,
   getAuthor,
+  getCurrentAuthor,
   updateProfile,
 } from '../controllers/author.controllers';
 
 router.use('/:id/posts', posts);
 
 router.get('/', paginate, getAllAuthors);
+router.get('/me', requiredLoggedIn, getCurrentAuthor);
 router.get('/:id', validate([param('id').isUUID()]), getAuthor);
 router.post(
   '/:id',

--- a/src/server/src/types/auth.ts
+++ b/src/server/src/types/auth.ts
@@ -1,10 +1,9 @@
 import express from 'express';
-import { v4 } from 'uuid';
-import Author from '../models/Author';
 
-type AuthenticatedRequest = express.Request & { author: Author } & {
-  authorId?: typeof v4;
+type AuthenticatedRequest = express.Request & {
+  authorId: string;
 };
+
 type AuthenticatedRequestHandler = (
   req: AuthenticatedRequest,
   res: express.Response,
@@ -12,7 +11,7 @@ type AuthenticatedRequestHandler = (
 ) => void;
 
 interface JwtPayload {
-  authorId: Author['id'];
+  authorId: string;
 }
 
 export { AuthenticatedRequest, AuthenticatedRequestHandler, JwtPayload };


### PR DESCRIPTION
This PR:
- implements login and registration on the frontend
- makes the /login and /register endpoint return the data of the author you are logging in as
- adds the /author/me endpoint that returns the data of the author you are logged in as
- improvements to api.ts on the frontend
- fix: changes uses of `res.sendStatus(x)` to `res.status(x).send()` on the backend

Right now there is no way in the UI to log out of the site. You can log out by running `localStorage.clear()` in the browser console and refreshing the page.