### PR TITLE
Fix: edit category

### DIFF
--- a/src/app/src/components/Edit.tsx
+++ b/src/app/src/components/Edit.tsx
@@ -126,7 +126,7 @@ const Edit = ({ id, currentUser, data }: any) => {
       contentType: type,
       content: content,
       image: 'mhm',
-      categories: category,
+      categories: (Array.isArray(category)?category:category.split(',')),
       count: 5,
       published: new Date(),
       visibility: visibility,
@@ -203,7 +203,7 @@ const Edit = ({ id, currentUser, data }: any) => {
             <MenuItem value="FRIENDS">Friends</MenuItem>
           </Select>
         </FormControl>
-        <ContentType>Categoies</ContentType>
+        <ContentType>Categories</ContentType>
         <TextField
           sx={{ width: '40%' }}
           id="standard-basic"


### PR DESCRIPTION
Ran into an edge case for editing posts. At the start, it converts the categories from an array of strings to a string so it can pre-fill the category form, but if you never touch/edit the categories it leaves it as a string which causes the server to return a 500 error. Just added a check before sending the post data and converting back to an array if needed.

`categories: (Array.isArray(category)?category:category.split(',')),`

Also fixed a missed typo where 'Categories' was spelled 'Categoies'