### PR TITLE
Conditional Buttons + ProfileImages

### DIFF
--- a/src/app/src/components/Add.tsx
+++ b/src/app/src/components/Add.tsx
@@ -15,6 +15,7 @@ import api from '../api/api';
 
 interface Props {
   currentUser?: Author;
+  handlePostsChanged:any;
 }
 const EditContainer = styled.div`
   background-color: white;
@@ -78,7 +79,7 @@ const CustomButton = Styled(Button)<ButtonProps>(({ theme }) => ({
     backgroundColor: '#b5b5b5',
   },
 }));
-const Add = ({ currentUser }: Props) => {
+const Add = ({ currentUser, handlePostsChanged }: Props) => {
   const [content, setContent] = React.useState('');
   const [openWrite, setOpenWrite] = React.useState(true);
   const [images, setImages] = React.useState<any>([]);
@@ -139,7 +140,12 @@ const Add = ({ currentUser }: Props) => {
       unlisted: unlisted,
     };
     // debugger;
-    api.authors.withId('' + currentUser?.id).posts.create(post);
+    api.authors
+    .withId('' + currentUser?.id)
+    .posts
+    .create(post)
+    .then(()=>handlePostsChanged())
+    .catch((error) => console.log(error));
   };
 
   React.useEffect(() => {

--- a/src/app/src/components/AdminAuthorCard.tsx
+++ b/src/app/src/components/AdminAuthorCard.tsx
@@ -34,14 +34,24 @@ export default function AdminAuthorCard({
                         width: '50%',
                         alignItems: 'center',
                     }}>
-                        {author.profileImage?(
-                            null
-                        ):
-                        <Avatar sx={{ width: 50, height: 50, mr:2}}>
-                            <PersonIcon
-                                sx={{ width: '100%', height: '100%' }}
+                        
+                        <Avatar sx={{ width: 50, height: 50, mr:2 }} >
+                        {author.profileImage ? 
+                            <Box
+                                component="img"
+                                src={author.profileImage}
+                                alt="profile image"
+                                height="100%"
+                                width="100%"
+                                style={{
+                                    borderRadius: "50%",
+                                    objectFit: "cover",
+                                }}
                             />
-                        </Avatar>}
+                            : (
+                            <PersonIcon sx={{ width: '75%', height: '75%' }} />
+                            )}
+                        </Avatar> 
                         
                         <Box display="block">
                             <Typography noWrap={true} sx={{ fontWeight: 'bold' }}>

--- a/src/app/src/components/Edit.tsx
+++ b/src/app/src/components/Edit.tsx
@@ -73,7 +73,7 @@ const CustomButton = Styled(Button)<ButtonProps>(({ theme }) => ({
     backgroundColor: '#b5b5b5',
   },
 }));
-const Edit = ({ id, currentUser, data }: any) => {
+const Edit = ({ id, currentUser, data, handlePostsChanged }: any) => {
   const [content, setContent] = React.useState(data.content);
   const [openWrite, setOpenWrite] = React.useState(true);
   const [images, setImages] = React.useState<any>([]);
@@ -137,6 +137,7 @@ const Edit = ({ id, currentUser, data }: any) => {
       .withId('' + currentUser?.id)
       .posts.withId('' + id)
       .update(post)
+      .then(()=>handlePostsChanged())
       .catch((e) => console.log(e.response));
   };
 

--- a/src/app/src/components/UserPost.tsx
+++ b/src/app/src/components/UserPost.tsx
@@ -7,8 +7,9 @@ import Backdrop from '@mui/material/Backdrop';
 import Edit from './Edit';
 import Author from '../api/models/Author';
 import Post from '../api/models/Post';
-import { Avatar } from '@mui/material';
+import { Avatar, Box } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
+import { useNavigate } from "react-router-dom";
 
 interface postItem {
   post: Post | undefined;
@@ -49,6 +50,9 @@ const TopRowContainer = styled.div`
 // This is for the author name
 const NameContainer = styled.div`
   padding: 1%;
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  font-weight: bold;
 `;
 // This is for the Edit and Delete buttons
 const EditDeleteButtonContainer = styled.div`
@@ -117,9 +121,14 @@ const DeleteButton = Styled(Button)<ButtonProps>(({ theme }) => ({
   },
 }));
 
+const cursorStyle = {
+  cursor:'pointer'
+};
+
 const UserPost: React.FC<postItem> = (props?) => {
   const [open, setOpen] = React.useState(false);
   const [likes, setLikes] = React.useState(props?.likes);
+  const navigate = useNavigate();
 
   let showButtons = false;
 
@@ -132,6 +141,10 @@ const UserPost: React.FC<postItem> = (props?) => {
   };
   const handleToggle = () => {
     setOpen(!open);
+  };
+
+  const HandleNavigation = () => { 
+    navigate(`/profile/${props?.postAuthor?.id}`) 
   };
 
   return (
@@ -166,16 +179,30 @@ const UserPost: React.FC<postItem> = (props?) => {
         <PostContainer>
           
           <PostProfilePictureContainer>
-            {props?.postAuthor?.profileImage ? null : (
-                <Avatar sx={{ width: 70, height: 70, m: 2 }}>
-                  <PersonIcon sx={{ width: '75%', height: '75%' }} />
-                </Avatar>
+            <Avatar onClick={HandleNavigation} style={cursorStyle} sx={{ width: 70, height: 70, m: 2 }} >
+            {props?.postAuthor?.profileImage ? 
+              <Box
+                  component="img"
+                  src={props.postAuthor.profileImage}
+                  alt="profile image"
+                  height="100%"
+                  width="100%"
+                  style={{
+                      borderRadius: "50%",
+                      objectFit: "cover",
+                  }}
+              />
+            : (
+              <PersonIcon sx={{ width: '75%', height: '75%' }} />
             )}
+            </Avatar> 
           </PostProfilePictureContainer>
 
           <PostDetailsContainer>
             <TopRowContainer>
-              <NameContainer>{props?.postAuthor?.displayName}</NameContainer>
+              <NameContainer onClick={HandleNavigation} style={cursorStyle} >
+                {props?.postAuthor?.displayName}
+              </NameContainer>
 
               {showButtons?(
                 <EditDeleteButtonContainer>
@@ -187,7 +214,7 @@ const UserPost: React.FC<postItem> = (props?) => {
             </TopRowContainer>
             <ContentContainer>{props?.post?.content}</ContentContainer>
             <LikesCommentsContainer>
-              <LikesContainer onClick={()=>setLikes(likes+1)}>{likes} Likes</LikesContainer>
+              <LikesContainer onClick={()=>setLikes(likes+1)} style={{cursor:'pointer'}}>{likes} Likes</LikesContainer>
               <CommentsContainer>{props?.post?.count} Comments</CommentsContainer>
             </LikesCommentsContainer>
           </PostDetailsContainer>

--- a/src/app/src/components/UserPost.tsx
+++ b/src/app/src/components/UserPost.tsx
@@ -6,18 +6,15 @@ import { CloseRounded } from '@mui/icons-material';
 import Backdrop from '@mui/material/Backdrop';
 import Edit from './Edit';
 import Author from '../api/models/Author';
+import Post from '../api/models/Post';
 import { Avatar } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
 
 interface postItem {
-  Name: string;
-  ContentText: string;
-  Likes: number;
-  Comments: number;
-  ProfilePicturePath?: string;
-  id?: any;
+  post: Post | undefined;
   currentUser: Author | undefined;
-  data?: any;
+  postAuthor: Author | undefined;
+  likes: number;
 }
 
 // This is for the whole Post, which includes the profile picure, content, etc
@@ -122,7 +119,13 @@ const DeleteButton = Styled(Button)<ButtonProps>(({ theme }) => ({
 
 const UserPost: React.FC<postItem> = (props?) => {
   const [open, setOpen] = React.useState(false);
-  const [likes, setLikes] = React.useState(props?.Likes);
+  const [likes, setLikes] = React.useState(props?.likes);
+
+  let showButtons = false;
+
+  if((props?.postAuthor && props?.currentUser)&&(props.currentUser.id===props.postAuthor.id)){
+    showButtons = true;
+  }
 
   const handleClose = () => {
     setOpen(false);
@@ -157,29 +160,35 @@ const UserPost: React.FC<postItem> = (props?) => {
               border: '1px solid white',
             }}
           />
-          <Edit id={props.id} currentUser={props.currentUser} data={props.data} />
+          <Edit id={props?.post?.id} currentUser={props.currentUser} data={props?.post} />
         </Backdrop>
       ) : (
         <PostContainer>
+          
           <PostProfilePictureContainer>
-            {props.currentUser?.profileImage ? null : (
+            {props?.postAuthor?.profileImage ? null : (
                 <Avatar sx={{ width: 70, height: 70, m: 2 }}>
                   <PersonIcon sx={{ width: '75%', height: '75%' }} />
                 </Avatar>
             )}
           </PostProfilePictureContainer>
+
           <PostDetailsContainer>
             <TopRowContainer>
-              <NameContainer>{props?.Name}</NameContainer>
-              <EditDeleteButtonContainer>
-                <EditButton onClick={handleToggle}>Edit</EditButton>
-                <DeleteButton>Delete</DeleteButton>
-              </EditDeleteButtonContainer>
+              <NameContainer>{props?.postAuthor?.displayName}</NameContainer>
+
+              {showButtons?(
+                <EditDeleteButtonContainer>
+                  <EditButton onClick={handleToggle}>Edit</EditButton>
+                  <DeleteButton>Delete</DeleteButton>
+                </EditDeleteButtonContainer>
+              ):null}
+
             </TopRowContainer>
-            <ContentContainer>{props?.ContentText}</ContentContainer>
+            <ContentContainer>{props?.post?.content}</ContentContainer>
             <LikesCommentsContainer>
               <LikesContainer onClick={()=>setLikes(likes+1)}>{likes} Likes</LikesContainer>
-              <CommentsContainer>{props?.Comments} Comments</CommentsContainer>
+              <CommentsContainer>{props?.post?.count} Comments</CommentsContainer>
             </LikesCommentsContainer>
           </PostDetailsContainer>
         </PostContainer>

--- a/src/app/src/components/UserPost.tsx
+++ b/src/app/src/components/UserPost.tsx
@@ -16,6 +16,7 @@ interface postItem {
   currentUser: Author | undefined;
   postAuthor: Author | undefined;
   likes: number;
+  handlePostsChanged:any;
 }
 
 // This is for the whole Post, which includes the profile picure, content, etc
@@ -173,7 +174,12 @@ const UserPost: React.FC<postItem> = (props?) => {
               border: '1px solid white',
             }}
           />
-          <Edit id={props?.post?.id} currentUser={props.currentUser} data={props?.post} />
+          <Edit 
+            id={props?.post?.id} 
+            currentUser={props.currentUser} 
+            data={props?.post} 
+            handlePostsChanged={props?.handlePostsChanged} 
+          />
         </Backdrop>
       ) : (
         <PostContainer>

--- a/src/app/src/pages/Admin.tsx
+++ b/src/app/src/pages/Admin.tsx
@@ -48,7 +48,7 @@ export default function Admin(): JSX.Element {
         .list(1,10)
         .then((data)=>setPosts(data))
         .catch((error) => {console.log(error)})
-    }, [id,posts])
+    }, [id])
 
     const nodes=[
         {

--- a/src/app/src/pages/Mainpage.tsx
+++ b/src/app/src/pages/Mainpage.tsx
@@ -72,7 +72,7 @@ export default function Mainpage({ currentUser }: Props) {
   useEffect(() => {
     api.authors
       .withId('' + currentUser?.id)
-      .posts.list(1, 100)
+      .posts.list(1, 10)
       .then((data) => {
         setPosts(data);
       })

--- a/src/app/src/pages/Mainpage.tsx
+++ b/src/app/src/pages/Mainpage.tsx
@@ -59,6 +59,7 @@ export default function Mainpage({ currentUser }: Props) {
   const handleClose = () => {
     setOpen(false);
   };
+
   const handleToggle = () => {
     setOpen(!open);
   };
@@ -71,7 +72,7 @@ export default function Mainpage({ currentUser }: Props) {
         setPosts(data);
       })
       .catch((error) => {});
-  }, [currentUser?.id, posts]);
+  }, [currentUser?.id]);
 
   return (
     <MainPageContainer>

--- a/src/app/src/pages/Mainpage.tsx
+++ b/src/app/src/pages/Mainpage.tsx
@@ -124,14 +124,11 @@ export default function Mainpage({ currentUser }: Props) {
           <List style={{ maxHeight: '100%', overflow: 'auto' }} sx={{ width: '70%', ml: 5 }}>
             {posts?.map((post) => (
               <UserPost
-                data={post}
-                Name={'' + currentUser?.displayName}
+                post={post}
                 currentUser={currentUser}
-                ContentText={post.content}
-                Likes={0}
-                Comments={post.count}
+                postAuthor={currentUser}
+                likes={0}
                 key={post.id}
-                id={post.id}
               />
             ))}
           </List>

--- a/src/app/src/pages/Mainpage.tsx
+++ b/src/app/src/pages/Mainpage.tsx
@@ -55,6 +55,7 @@ export default function Mainpage({ currentUser }: Props) {
   // For now, mainpage just shows your own posts
   const [posts, setPosts] = useState<Post[] | undefined>(undefined);
   const [open, setOpen] = useState(false);
+  const [postsChanged, setpostsChanged] = useState(false);
 
   const handleClose = () => {
     setOpen(false);
@@ -64,15 +65,19 @@ export default function Mainpage({ currentUser }: Props) {
     setOpen(!open);
   };
 
+  const handlePostsChanged = () => {
+    setpostsChanged(!postsChanged);
+  };
+
   useEffect(() => {
     api.authors
       .withId('' + currentUser?.id)
-      .posts.list(1, 5)
+      .posts.list(1, 100)
       .then((data) => {
         setPosts(data);
       })
       .catch((error) => {});
-  }, [currentUser?.id]);
+  }, [currentUser?.id, postsChanged]);
 
   return (
     <MainPageContainer>
@@ -118,7 +123,7 @@ export default function Mainpage({ currentUser }: Props) {
               border: '1px solid white',
             }}
           />
-          <Add currentUser={currentUser} />
+          <Add currentUser={currentUser} handlePostsChanged={handlePostsChanged} />
         </Backdrop>
       ) : (
         <MainPageContentContainer>
@@ -129,6 +134,7 @@ export default function Mainpage({ currentUser }: Props) {
                 currentUser={currentUser}
                 postAuthor={currentUser}
                 likes={0}
+                handlePostsChanged={handlePostsChanged}
                 key={post.id}
               />
             ))}

--- a/src/app/src/pages/Profile.tsx
+++ b/src/app/src/pages/Profile.tsx
@@ -42,7 +42,7 @@ export default function Profile({ currentUser }: Props): JSX.Element {
       .catch((error) => {
         console.log(error);
       });
-  }, [id, posts]);
+  }, [id]);
 
   // If it's your profle - Edit
   let myProfile = false;

--- a/src/app/src/pages/Profile.tsx
+++ b/src/app/src/pages/Profile.tsx
@@ -92,11 +92,23 @@ export default function Profile({ currentUser }: Props): JSX.Element {
                 bgcolor: '#fff',
               }}
             >
-              {author.profileImage ? null : (
-                <Avatar sx={{ width: 150, height: 150, m: 2 }}>
-                  <PersonIcon sx={{ width: 100, height: 100 }} />
-                </Avatar>
-              )}
+            <Avatar sx={{ width: 150, height: 150 }} >
+            {author.profileImage ? 
+              <Box
+                  component="img"
+                  src={author.profileImage}
+                  alt="profile image"
+                  height="100%"
+                  width="100%"
+                  style={{
+                      borderRadius: "50%",
+                      objectFit: "cover",
+                  }}
+              />
+            : (
+              <PersonIcon sx={{ width: '75%', height: '75%' }} />
+            )}
+            </Avatar> 
 
               <Typography variant="h4" align="center">
                 {author.displayName}

--- a/src/app/src/pages/Profile.tsx
+++ b/src/app/src/pages/Profile.tsx
@@ -33,6 +33,11 @@ export default function Profile({ currentUser }: Props): JSX.Element {
 
   //Get author's posts
   const [posts, setPosts] = useState<Post[] | undefined>(undefined);
+  const [postsChanged, setpostsChanged] = useState(false);
+
+  const handlePostsChanged = () => {
+    setpostsChanged(!postsChanged);
+  };
 
   useEffect(() => {
     api.authors
@@ -42,7 +47,7 @@ export default function Profile({ currentUser }: Props): JSX.Element {
       .catch((error) => {
         console.log(error);
       });
-  }, [id]);
+  }, [id,postsChanged]);
 
   // If it's your profle - Edit
   let myProfile = false;
@@ -176,6 +181,7 @@ export default function Profile({ currentUser }: Props): JSX.Element {
                     currentUser={currentUser}
                     postAuthor={author}
                     likes={0}
+                    handlePostsChanged={handlePostsChanged}
                     key={post.id}
                   />
                 ))}

--- a/src/app/src/pages/Profile.tsx
+++ b/src/app/src/pages/Profile.tsx
@@ -160,13 +160,11 @@ export default function Profile({ currentUser }: Props): JSX.Element {
               <List style={{ maxHeight: '100%', overflow: 'auto' }} sx={{width:'100%'}}>
                 {posts?.map((post) => (
                   <UserPost
+                    post={post}
                     currentUser={currentUser}
-                    Name={author.displayName}
-                    ContentText={post.content}
-                    Likes={0}
-                    Comments={post.count}
+                    postAuthor={author}
+                    likes={0}
                     key={post.id}
-                    id={post.id}
                   />
                 ))}
               </List>


### PR DESCRIPTION
Added conditional rendering of buttons in UserPost.
Restructured UserPost props.
Added profileImage rendering if not null. (no way to upload rn, just added a link to an image for one of the authors)
Clicking a user's profile image or displayname in userPosts redirects you to their profile page.
EDIT: Added a fix for infinite api calls.

Main Page:
<img width="1280" alt="Screen Shot 2022-03-08 at 2 33 40 PM" src="https://user-images.githubusercontent.com/55111012/157330147-69a926fd-4ce0-436c-b01f-f4d10f00f606.png">

Others Profile:
<img width="1280" alt="Screen Shot 2022-03-08 at 2 33 31 PM" src="https://user-images.githubusercontent.com/55111012/157330137-4910568b-edcb-42ed-8583-4584a5f280b5.png">

My profile:
<img width="1280" alt="Screen Shot 2022-03-08 at 2 33 47 PM" src="https://user-images.githubusercontent.com/55111012/157330157-77e423b3-b548-4ccf-9d68-46c8616b2199.png">

Admin authors:
<img width="1280" alt="Screen Shot 2022-03-08 at 2 38 24 PM" src="https://user-images.githubusercontent.com/55111012/157330180-03728234-facd-446c-8a93-93e0e36ce65d.png">

