### PR TITLE
Some backend fixes for remote nodes

### DIFF
--- a/src/server/src/controllers/post.controllers.ts
+++ b/src/server/src/controllers/post.controllers.ts
@@ -22,7 +22,7 @@ const createPost = async (req: AuthenticatedRequest, res: Response) => {
     origin,
     contentType,
     content,
-    categories,
+    // categories,
     visibility,
   } = req.body;
 
@@ -48,7 +48,7 @@ const createPost = async (req: AuthenticatedRequest, res: Response) => {
         image: Buffer.from(req.file.buffer).toString('base64'),
       }),
       content: content,
-      categories: categories ? categories : [],
+      categories: [], // TODO: set categories
       visibility: visibility,
     });
     author.addPost(post);

--- a/src/server/src/middlewares/pagination.middlewares.ts
+++ b/src/server/src/middlewares/pagination.middlewares.ts
@@ -6,24 +6,28 @@ const paginate = (
   res: Response,
   next: NextFunction
 ) => {
-  if (req.query.page && req.query.size) {
-    if (
-      isNaN(parseInt(req.query.page.toString())) ||
-      isNaN(parseInt(req.query.size.toString()))
-    ) {
-      res
-        .status(400)
-        .send({ error: 'Parameter page and size must be an integer' });
+  let page = 1;
+  let size = 10;
+
+  if (req.query.size) {
+    size = parseInt(req.query.size.toString());
+    if (isNaN(size) || size < 1) {
+      res.status(400).send({ error: 'size must be a positive integer' });
       return;
     }
-    req.limit = parseInt(req.query.size.toString());
-    req.offset = (parseInt(req.query.page.toString()) - 1) * req.limit;
-    next();
-    return;
   }
-  res.status(400).send({
-    error: 'This request must be paginated using the parameter page and size',
-  });
+
+  if (req.query.page) {
+    page = parseInt(req.query.page.toString());
+    if (isNaN(page) || page < 1) {
+      res.status(400).send({ error: 'page must be a positive integer' });
+      return;
+    }
+  }
+
+  req.limit = size;
+  req.offset = (page - 1) * req.limit;
+  next();
 };
 
 export { paginate };


### PR DESCRIPTION
This PR:
- temporarily removes categories from post creation, as it currently causes a 500 error since categories is a string
- makes pagination query parameters default to page 1 and size 10