### PR TITLE
Mainpage Likes and Comments Components

### DIFF
--- a/src/app/src/components/Add.tsx
+++ b/src/app/src/components/Add.tsx
@@ -22,6 +22,7 @@ import api from '../api/api';
 interface Props {
   currentUser?: Author;
   handlePostsChanged:any;
+  handleClose:any;
 }
 const EditContainer = styled.div`
   background-color: white;
@@ -88,7 +89,7 @@ const CustomButton = Styled(Button)<ButtonProps>(({ theme }) => ({
 const fieldStyle = { width: '40%', mt:3 };
 const formStyle = { m: 1, minWidth: 120, width: '40%', mt:2 };
 
-const Add = ({ currentUser, handlePostsChanged }: Props) => {
+const Add = ({ currentUser, handlePostsChanged, handleClose }: Props) => {
   const [content, setContent] = React.useState('');
   const [openWrite, setOpenWrite] = React.useState(true);
   const [images, setImages] = React.useState<any>([]);
@@ -160,7 +161,7 @@ const Add = ({ currentUser, handlePostsChanged }: Props) => {
     .withId('' + currentUser?.id)
     .posts
     .create(formData)
-    .then(()=>handlePostsChanged())
+    .then(()=>{handlePostsChanged(); handleClose()})
     .catch((error) => console.log(error));
   };
 

--- a/src/app/src/components/Add.tsx
+++ b/src/app/src/components/Add.tsx
@@ -31,6 +31,7 @@ const EditContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  border-radius: 10px;
 `;
 const Block = styled.div`
   width: 100%;
@@ -44,8 +45,6 @@ const Block = styled.div`
 `;
 const Header = styled.div`
   margin-top: 1%;
-  text-decoration: underline;
-  font-family: Avenir Next Light;
   font-size: 200%;
   text-align: center;
 `;
@@ -61,7 +60,6 @@ const ContentType = styled.div`
   width: 80%;
   text-align: center;
   margin-top: 2%;
-  font-family: Avenir Next Light;
   font-size: 150%;
 `;
 
@@ -77,6 +75,7 @@ const ActualContent = styled.div`
   margin-top: 2%;
   width: 50%;
 `;
+
 const CustomButton = Styled(Button)<ButtonProps>(({ theme }) => ({
   color: theme.palette.getContrastText('#fff'),
   padding: '10px',
@@ -85,6 +84,10 @@ const CustomButton = Styled(Button)<ButtonProps>(({ theme }) => ({
     backgroundColor: '#b5b5b5',
   },
 }));
+
+const fieldStyle = { width: '40%', mt:3 };
+const formStyle = { m: 1, minWidth: 120, width: '40%', mt:2 };
+
 const Add = ({ currentUser, handlePostsChanged }: Props) => {
   const [content, setContent] = React.useState('');
   const [openWrite, setOpenWrite] = React.useState(true);
@@ -173,10 +176,9 @@ const Add = ({ currentUser, handlePostsChanged }: Props) => {
   return (
     <EditContainer>
       <Block>
-        <Header>Add</Header>
-        <ContentType>Title</ContentType>
+        <Header>Add Post</Header>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id='standard-basic'
           required
           label='Title'
@@ -184,17 +186,15 @@ const Add = ({ currentUser, handlePostsChanged }: Props) => {
           onChange={handleTitleChange}
           fullWidth
         />
-        <ContentType>Description</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id='standard-basic'
           label='Description'
           value={description}
           onChange={handleDescriptionChange}
           fullWidth
         />
-        <ContentType>Type</ContentType>
-        <FormControl variant='standard' sx={{ m: 1, minWidth: 120 }}>
+        <FormControl variant='standard' sx={formStyle}>
           <InputLabel id='demo-simple-select-standard-label' required>
             Type
           </InputLabel>
@@ -209,8 +209,7 @@ const Add = ({ currentUser, handlePostsChanged }: Props) => {
             <MenuItem value='image'>Image</MenuItem>
           </Select>
         </FormControl>
-        <ContentType>Visibility</ContentType>
-        <FormControl variant='standard' sx={{ m: 1, minWidth: 120 }}>
+        <FormControl variant='standard' sx={formStyle}>
           <InputLabel id='demo-simple-select-standard-label' required>
             Visibility
           </InputLabel>
@@ -224,9 +223,8 @@ const Add = ({ currentUser, handlePostsChanged }: Props) => {
             <MenuItem value='FRIENDS'>Friends</MenuItem>
           </Select>
         </FormControl>
-        <ContentType>Category</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id='standard-basic'
           label='Category'
           value={category}

--- a/src/app/src/components/AddAuthor.tsx
+++ b/src/app/src/components/AddAuthor.tsx
@@ -18,6 +18,7 @@ const EditContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  border-radius: 10px;
 `;
 const Block = styled.div`
   width: 100%;
@@ -31,19 +32,11 @@ const Block = styled.div`
 `;
 const Header = styled.div`
   margin-top: 1%;
-  text-decoration: underline;
-  font-family: Avenir Next Light;
   font-size: 200%;
   text-align: center;
 `;
 
-const ContentType = styled.div`
-  width: 80%;
-  text-align: center;
-  margin-top: 2%;
-  font-family: Avenir Next Light;
-  font-size: 150%;
-`;
+const fieldStyle = { width: '40%', mt:5 };
 
 const AddAuthor = ({ handleAuthorsChanged, handleClose }: Props) => {
   const [displayName, setName] = React.useState("");
@@ -73,10 +66,9 @@ const AddAuthor = ({ handleAuthorsChanged, handleClose }: Props) => {
   return (
     <EditContainer>
       <Block>
-      <Header>Add</Header>
-        <ContentType>Display Name</ContentType>
+      <Header>Add Author</Header>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           required
           label="display name"
@@ -84,9 +76,8 @@ const AddAuthor = ({ handleAuthorsChanged, handleClose }: Props) => {
           onChange={handleName}
           fullWidth
         />
-        <ContentType>Email</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           required
           label="email"
@@ -94,9 +85,8 @@ const AddAuthor = ({ handleAuthorsChanged, handleClose }: Props) => {
           onChange={handleEmail}
           fullWidth
         />
-        <ContentType>Password</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           required
           label="password"
@@ -109,7 +99,7 @@ const AddAuthor = ({ handleAuthorsChanged, handleClose }: Props) => {
       <Fab
         color="primary"
         aria-label="check"
-        sx={{ color: 'black', background: '#46ECA6', '&:hover': { background: '#18E78F' } }}
+        sx={{ color: 'black', background: '#46ECA6', '&:hover': { background: '#18E78F' }, mb: 5 }}
       >
         <CheckIcon onClick={handleEdit} />
       </Fab>

--- a/src/app/src/components/AddNode.tsx
+++ b/src/app/src/components/AddNode.tsx
@@ -18,6 +18,7 @@ const EditContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  border-radius: 10px;
 `;
 const Block = styled.div`
   width: 100%;
@@ -31,19 +32,11 @@ const Block = styled.div`
 `;
 const Header = styled.div`
   margin-top: 1%;
-  text-decoration: underline;
-  font-family: Avenir Next Light;
   font-size: 200%;
   text-align: center;
 `;
 
-const ContentType = styled.div`
-  width: 80%;
-  text-align: center;
-  margin-top: 2%;
-  font-family: Avenir Next Light;
-  font-size: 150%;
-`;
+const fieldStyle = { width: '40%', mt:5 };
 
 const AddNode = ({ handleNodesChanged, handleClose }: Props) => {
   const [username, setName] = React.useState("");
@@ -69,10 +62,9 @@ const AddNode = ({ handleNodesChanged, handleClose }: Props) => {
   return (
     <EditContainer>
       <Block>
-      <Header>Add</Header>
-        <ContentType>Username</ContentType>
+      <Header>Add Node</Header>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           required
           label="username"
@@ -80,9 +72,8 @@ const AddNode = ({ handleNodesChanged, handleClose }: Props) => {
           onChange={handleName}
           fullWidth
         />
-        <ContentType>Password</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           required
           label="password"
@@ -95,7 +86,7 @@ const AddNode = ({ handleNodesChanged, handleClose }: Props) => {
       <Fab
         color="primary"
         aria-label="check"
-        sx={{ color: 'black', background: '#46ECA6', '&:hover': { background: '#18E78F' } }}
+        sx={{ color: 'black', background: '#46ECA6', '&:hover': { background: '#18E78F' }, mb: 5 }}
       >
         <CheckIcon onClick={handleEdit} />
       </Fab>

--- a/src/app/src/components/Edit.tsx
+++ b/src/app/src/components/Edit.tsx
@@ -75,7 +75,7 @@ const CustomButton = Styled(Button)<ButtonProps>(({ theme }) => ({
 const fieldStyle = { width: '40%', mt:3 };
 const formStyle = { m: 1, minWidth: 120, width: '40%', mt:2 };
 
-const Edit = ({ id, currentUser, data, handlePostsChanged }: any) => {
+const Edit = ({ id, currentUser, data, handlePostsChanged, handleClose }: any) => {
   const [content, setContent] = React.useState(data.content);
   const [openWrite, setOpenWrite] = React.useState(true);
   const [images, setImages] = React.useState<any>([]);
@@ -146,7 +146,7 @@ const Edit = ({ id, currentUser, data, handlePostsChanged }: any) => {
       .withId('' + currentUser?.id)
       .posts.withId('' + id)
       .update(formData)
-      .then(() => handlePostsChanged())
+      .then(() => {handlePostsChanged(); handleClose()})
       .catch((e) => console.log(e.response));
   };
 

--- a/src/app/src/components/Edit.tsx
+++ b/src/app/src/components/Edit.tsx
@@ -19,6 +19,7 @@ const EditContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  border-radius: 10px;
 `;
 const Block = styled.div`
   width: 100%;
@@ -32,8 +33,6 @@ const Block = styled.div`
 `;
 const Header = styled.div`
   margin-top: 1%;
-  text-decoration: underline;
-  font-family: Avenir Next Light;
   font-size: 200%;
   text-align: center;
 `;
@@ -49,7 +48,6 @@ const ContentType = styled.div`
   width: 80%;
   text-align: center;
   margin-top: 2%;
-  font-family: Avenir Next Light;
   font-size: 150%;
 `;
 
@@ -73,6 +71,10 @@ const CustomButton = Styled(Button)<ButtonProps>(({ theme }) => ({
     backgroundColor: '#b5b5b5',
   },
 }));
+
+const fieldStyle = { width: '40%', mt:3 };
+const formStyle = { m: 1, minWidth: 120, width: '40%', mt:2 };
+
 const Edit = ({ id, currentUser, data, handlePostsChanged }: any) => {
   const [content, setContent] = React.useState(data.content);
   const [openWrite, setOpenWrite] = React.useState(true);
@@ -158,10 +160,9 @@ const Edit = ({ id, currentUser, data, handlePostsChanged }: any) => {
   return (
     <EditContainer>
       <Block>
-        <Header>Edit</Header>
-        <ContentType>Title</ContentType>
+        <Header>Edit Post</Header>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           required
           label="Title"
@@ -169,17 +170,15 @@ const Edit = ({ id, currentUser, data, handlePostsChanged }: any) => {
           onChange={handleTitleChange}
           fullWidth
         />
-        <ContentType>Description</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           label="Description"
           value={description}
           onChange={handleDescriptionChange}
           fullWidth
         />
-        <ContentType>Type</ContentType>
-        <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }}>
+        <FormControl variant="standard" sx={formStyle}>
           <InputLabel id="demo-simple-select-standard-label" required>
             Type
           </InputLabel>
@@ -195,8 +194,7 @@ const Edit = ({ id, currentUser, data, handlePostsChanged }: any) => {
             <MenuItem value="image/png;base64">Image</MenuItem>
           </Select>
         </FormControl>
-        <ContentType>Visibility</ContentType>
-        <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }}>
+        <FormControl variant="standard" sx={formStyle}>
           <InputLabel id="demo-simple-select-standard-label" required>
             Visibility
           </InputLabel>
@@ -211,9 +209,8 @@ const Edit = ({ id, currentUser, data, handlePostsChanged }: any) => {
             <MenuItem value="FRIENDS">Friends</MenuItem>
           </Select>
         </FormControl>
-        <ContentType>Categories</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           label="Categories"
           value={category}

--- a/src/app/src/components/EditAuthor.tsx
+++ b/src/app/src/components/EditAuthor.tsx
@@ -21,6 +21,7 @@ const EditContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  border-radius: 10px;
 `;
 const Block = styled.div`
   width: 100%;
@@ -34,19 +35,11 @@ const Block = styled.div`
 `;
 const Header = styled.div`
   margin-top: 1%;
-  text-decoration: underline;
-  font-family: Avenir Next Light;
   font-size: 200%;
   text-align: center;
 `;
 
-const ContentType = styled.div`
-  width: 80%;
-  text-align: center;
-  margin-top: 2%;
-  font-family: Avenir Next Light;
-  font-size: 150%;
-`;
+const fieldStyle = { width: '40%', mt:5 };
 
 const EditAuthor = ({ data, handleAuthorsChanged, handleClose }: Props) => {
   const [displayName, setName] = React.useState(data.displayName);
@@ -90,10 +83,9 @@ const EditAuthor = ({ data, handleAuthorsChanged, handleClose }: Props) => {
   return (
     <EditContainer>
       <Block>
-      <Header>Edit</Header>
-        <ContentType>Display Name</ContentType>
+      <Header>Edit Author</Header>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           required
           label="displayName"
@@ -101,18 +93,16 @@ const EditAuthor = ({ data, handleAuthorsChanged, handleClose }: Props) => {
           onChange={handleNameChange}
           fullWidth
         />
-        <ContentType>Github</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           label="github"
           value={github}
           onChange={handleGithub}
           fullWidth
         />
-        <ContentType>Profile Image</ContentType>
         <TextField
-          sx={{ width: '40%' }}
+          sx={fieldStyle}
           id="standard-basic"
           label="imageURL"
           value={profileImage}
@@ -123,7 +113,7 @@ const EditAuthor = ({ data, handleAuthorsChanged, handleClose }: Props) => {
       <Fab
         color="primary"
         aria-label="check"
-        sx={{ color: 'black', background: '#46ECA6', '&:hover': { background: '#18E78F' } }}
+        sx={{ color: 'black', background: '#46ECA6', '&:hover': { background: '#18E78F' }, mb:5 }}
       >
         <CheckIcon onClick={handleEdit} />
       </Fab>

--- a/src/app/src/components/Github.tsx
+++ b/src/app/src/components/Github.tsx
@@ -29,7 +29,6 @@ const GithubHeader = styled.div`
   align-items: center;
   justify-content: center;
   font-size: 150%;
-  font-family: Avenir Next Light;
 `;
 const Github = ({ username }: props) => {
   const [items, setItems] = useState<Array<any>>([]);

--- a/src/app/src/components/MainComment.tsx
+++ b/src/app/src/components/MainComment.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { Box, Card, CardContent, Typography } from "@mui/material";
+import Comment from "../api/models/Comment"
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+
+export default function MainComment({
+    comment,
+}: {
+    comment: Comment,
+}): JSX.Element {
+    const handleClick = () =>{
+        window.open(`${comment.postId}`,"_blank");
+    }
+
+    return (
+    <Box style={{
+        width: '90%',
+        display: 'flex',}}
+    >
+        <Card 
+            variant="outlined"
+            sx={{
+            my:1,
+            boxShadow:2,
+            width:'90%',
+            ml: 13,
+            }}
+        >
+            <CardContent sx={{
+                height:15,
+                width: '90%',
+            }}>
+                <Box style={{
+                        display: 'flex',
+                        alignItems: 'center'}}
+                    sx={{
+                        width: '100%',
+                        height:'100%',
+                    }}>
+                    <ChatBubbleOutlineIcon/>
+                        <Typography noWrap ml={0.5}>
+                            {comment.author.displayName} commented on your post: <Box style={{textDecoration: 'underline', cursor:'pointer'}} component="span" onClick={handleClick}>{comment.postId}</Box>
+                        </Typography>
+                    </Box>
+            </CardContent>
+        </Card>
+    </Box>
+  );
+};
+

--- a/src/app/src/components/MainLike.tsx
+++ b/src/app/src/components/MainLike.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { Box, Card, CardContent, Typography } from "@mui/material";
+import Like from "../api/models/Like"
+import FavoriteIcon from '@mui/icons-material/Favorite';
+
+export default function MainLike({
+    like,
+}: {
+    like: Like,
+}): JSX.Element {
+    const handleClick = () =>{
+        window.open(`${like.object}`,"_blank");
+    }
+    return (
+    <Box style={{
+        width: '90%',
+        display: 'flex',}}
+    >
+        <Card 
+            variant="outlined"
+            sx={{
+            my:1,
+            boxShadow:2,
+            width:'90%',
+            ml: 13,
+            }}
+        >
+            <CardContent sx={{
+                height:15,
+                width: '90%',
+            }}>
+                <Box style={{
+                        display: 'flex',
+                        alignItems: 'center'}}
+                    sx={{
+                        width: '100%',
+                        height:'100%',
+                    }}>
+                    <FavoriteIcon/>
+                    <Typography noWrap ml={0.5}>
+                            {like.summary}: <Box style={{textDecoration: 'underline', cursor:'pointer'}} component="span" onClick={handleClick}>{like.object}</Box>
+                        </Typography>
+                    </Box>
+
+            </CardContent>
+        </Card>
+    </Box>
+  );
+};
+

--- a/src/app/src/components/UserPost.tsx
+++ b/src/app/src/components/UserPost.tsx
@@ -228,6 +228,7 @@ const UserPost: React.FC<postItem> = (props?) => {
             currentUser={props.currentUser}
             data={props?.post}
             handlePostsChanged={props?.handlePostsChanged}
+            handleClose={handleClose}
           />
         </Backdrop>
       ) : (

--- a/src/app/src/pages/Mainpage.tsx
+++ b/src/app/src/pages/Mainpage.tsx
@@ -12,6 +12,10 @@ import { CloseRounded } from '@mui/icons-material';
 import Fab from '@mui/material/Fab';
 import AddIcon from '@mui/icons-material/Add';
 import { List } from '@mui/material';
+import Like from '../api/models/Like';
+import MainLike from '../components/MainLike';
+import Comment from '../api/models/Comment';
+import MainComment from '../components/MainComment';
 
 // This is for all the stuff in the Main Page
 const MainPageContainer = styled.div`
@@ -82,6 +86,31 @@ export default function Mainpage({ currentUser }: Props) {
       .then((data) => setPosts(data));
   }, [currentUser?.id, postsChanged]);
 
+  //Fake data to show likes/comments
+  const likeAuthor: Author = {
+    type: "author",
+    id: 'http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e',
+    displayName: 'Lara Croft',
+    isAdmin: false,
+  };
+
+  const like: Like = {
+    type: "Like",
+    summary: 'Lara Croft liked your post',
+    author: likeAuthor,
+    object: 'http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/de305d54-75b4-431b-adb2-eb6b9e546013'
+  }
+
+  const comment: Comment = {
+    type: "comment",
+    id: 'http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/de305d54-75b4-431b-adb2-eb6b9e546013/comments/f6255bb01c648fe967714d52a89e8e9c',
+    author: likeAuthor,
+    comment: 'Wow!',
+    contentType: 'text/plain',
+    published: '2015-03-09T13:07:04+00:00',
+    postId: 'http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/de305d54-75b4-431b-adb2-eb6b9e546013'
+  }
+
   return (
     <MainPageContainer>
       <NavBarContainer>
@@ -141,9 +170,18 @@ export default function Mainpage({ currentUser }: Props) {
                 key={post.id}
               />
             ))}
+              <MainLike 
+                key={like.author.id}
+                like={like}
+              />
+
+              <MainComment 
+                key={comment.author.id}
+                comment={comment}
+              />
           </List>
           <GitContainer>
-            <Github username={currentUser?.displayName} />
+            <Github username={currentUser?.github ? `${currentUser.github.split('/').pop()}`:''} />
           </GitContainer>
         </MainPageContentContainer>
       )}

--- a/src/app/src/pages/Mainpage.tsx
+++ b/src/app/src/pages/Mainpage.tsx
@@ -12,10 +12,6 @@ import { CloseRounded } from '@mui/icons-material';
 import Fab from '@mui/material/Fab';
 import AddIcon from '@mui/icons-material/Add';
 import { List } from '@mui/material';
-import Like from '../api/models/Like';
-import MainLike from '../components/MainLike';
-import Comment from '../api/models/Comment';
-import MainComment from '../components/MainComment';
 
 // This is for all the stuff in the Main Page
 const MainPageContainer = styled.div`
@@ -86,31 +82,6 @@ export default function Mainpage({ currentUser }: Props) {
       .then((data) => setPosts(data));
   }, [currentUser?.id, postsChanged]);
 
-  //Fake data to show likes/comments
-  const likeAuthor: Author = {
-    type: "author",
-    id: 'http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e',
-    displayName: 'Lara Croft',
-    isAdmin: false,
-  };
-
-  const like: Like = {
-    type: "Like",
-    summary: 'Lara Croft liked your post',
-    author: likeAuthor,
-    object: 'http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/de305d54-75b4-431b-adb2-eb6b9e546013'
-  }
-
-  const comment: Comment = {
-    type: "comment",
-    id: 'http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/de305d54-75b4-431b-adb2-eb6b9e546013/comments/f6255bb01c648fe967714d52a89e8e9c',
-    author: likeAuthor,
-    comment: 'Wow!',
-    contentType: 'text/plain',
-    published: '2015-03-09T13:07:04+00:00',
-    postId: 'http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/de305d54-75b4-431b-adb2-eb6b9e546013'
-  }
-
   return (
     <MainPageContainer>
       <NavBarContainer>
@@ -155,7 +126,7 @@ export default function Mainpage({ currentUser }: Props) {
               border: '1px solid white',
             }}
           />
-          <Add currentUser={currentUser} handlePostsChanged={handlePostsChanged} />
+          <Add currentUser={currentUser} handlePostsChanged={handlePostsChanged} handleClose={handleClose}/>
         </Backdrop>
       ) : (
         <MainPageContentContainer>
@@ -170,15 +141,6 @@ export default function Mainpage({ currentUser }: Props) {
                 key={post.id}
               />
             ))}
-              <MainLike 
-                key={like.author.id}
-                like={like}
-              />
-
-              <MainComment 
-                key={comment.author.id}
-                comment={comment}
-              />
           </List>
           <GitContainer>
             <Github username={currentUser?.github ? `${currentUser.github.split('/').pop()}`:''} />

--- a/src/app/src/pages/__tests__/__snapshots__/Mainpage.test.tsx.snap
+++ b/src/app/src/pages/__tests__/__snapshots__/Mainpage.test.tsx.snap
@@ -119,12 +119,12 @@ exports[`Mainpage suite Renders correctly 1`] = `
         className="sc-fFeiMQ ejkoIZ"
       >
         <div
-          className="sc-bkkeKt bUsYpp"
+          className="sc-bkkeKt Qfuew"
         >
           Github Activity
         </div>
         <div
-          className="sc-bkkeKt bUsYpp"
+          className="sc-bkkeKt Qfuew"
         >
           <span
             className="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorSuccess css-15u8j6q-MuiCircularProgress-root"


### PR DESCRIPTION
Added components for Likes and Comment in the inbox.
Updated the looks of all Add/Edit components.
Add/Edit posts now close themselves after successful submission.
Github activity now parses your username from your given github url instead of display name.

What they should look like when inbox is used. MainComment takes a comment object as input, MainLike takes a like object as input. Clicking the url should ideally redirect you to the liked/commented post.
<img width="1278" alt="Screen Shot 2022-03-30 at 5 38 01 PM" src="https://user-images.githubusercontent.com/55111012/161106413-37d734e3-0081-4e53-94f6-7b21b036e370.png">

Example updated Add Post, all admin Add/Edits were updated similarly:
<img width="1280" alt="Screen Shot 2022-03-30 at 5 38 13 PM" src="https://user-images.githubusercontent.com/55111012/161106847-aa5561c9-9115-487d-a634-28757aa480ca.png">

