### PR TITLE
Allow Authors, Posts, and Comments to refer to remote entities

### DIFF
--- a/src/server/src/controllers/author.controllers.ts
+++ b/src/server/src/controllers/author.controllers.ts
@@ -48,9 +48,16 @@ const getAllAuthors = async (req: PaginationRequest, res: Response) => {
     offset: req.offset,
     limit: req.limit,
   });
+
+  const local_authors = []; // only includes local authors: no authors from remote nodes
+  for (let i = 0; i < authors.length; i++) {
+    if (authors[i].email !== null) {
+      local_authors.push(authors[i]);
+    }
+  }
   res.send({
     type: 'authors',
-    items: authors.map((author) => serializeAuthor(author, req)),
+    items: local_authors.map((author) => serializeAuthor(author, req)),
   });
 };
 

--- a/src/server/src/controllers/comment.controllers.ts
+++ b/src/server/src/controllers/comment.controllers.ts
@@ -8,11 +8,7 @@ import { getHost } from '../utilities/host';
 import { pick } from '../utilities/pick';
 import { serializeAuthor } from './author.controllers';
 
-export const serializeComment = (
-  comment: Comment,
-  //post: Post,
-  req: Request
-) => ({
+export const serializeComment = (comment: Comment, req: Request) => ({
   type: 'comment',
   ...pick(comment.toJSON(), ['comment', 'contentType', 'published']),
   author: serializeAuthor(comment.author, req),
@@ -27,12 +23,12 @@ const createComment = async (req: AuthenticatedRequest, res: Response) => {
 
   const post = await Post.findOne({
     where: {
-      id: req.params.post_id,
+      id: req.params.postId,
     },
   });
   const author = await Author.findOne({
     where: {
-      id: req.params.id,
+      id: req.params.authorId,
     },
   });
   if (post === null) {
@@ -60,7 +56,7 @@ const getPostComment = async (req: Request, res: Response) => {
   const comment = await Comment.findOne({
     attributes: ['comment', 'contentType', 'published', 'id'],
     where: {
-      post_id: req.params.post_id,
+      post_id: req.params.postId,
     },
     include: [
       {
@@ -91,7 +87,7 @@ const getPostComment = async (req: Request, res: Response) => {
 };
 
 const getPostComments = async (req: PaginationRequest, res: Response) => {
-  const post = await Post.findByPk(req.params.post_id);
+  const post = await Post.findByPk(req.params.postId);
   if (post === null) {
     res.status(404).send({ error: 'Post does not exist' });
     return;
@@ -100,7 +96,7 @@ const getPostComments = async (req: PaginationRequest, res: Response) => {
   const comments = await Comment.findAll({
     attributes: ['comment', 'contentType', 'published', 'id'],
     where: {
-      post_id: req.params.post_id,
+      post_id: req.params.postId,
     },
     include: [
       {
@@ -125,16 +121,9 @@ const getPostComments = async (req: PaginationRequest, res: Response) => {
     limit: req.limit,
   });
 
-  const local_comments = []; // only included local comments: no comments from remote nodes
-  for (let i = 0; i < comments.length; i++) {
-    if (comments[i].comment !== null) {
-      local_comments.push(comments[i]);
-    }
-  }
-
   res.send({
     type: 'comments',
-    comments: local_comments.map((comment) => serializeComment(comment, req)),
+    comments: comments.map((comment) => serializeComment(comment, req)),
   });
 };
 

--- a/src/server/src/controllers/comment.controllers.ts
+++ b/src/server/src/controllers/comment.controllers.ts
@@ -55,6 +55,7 @@ const createComment = async (req: AuthenticatedRequest, res: Response) => {
   res.status(200).send();
 };
 
+// this should not be used as not in the specs, but is there for testing
 const getPostComment = async (req: Request, res: Response) => {
   const comment = await Comment.findOne({
     attributes: ['comment', 'contentType', 'published', 'id'],
@@ -123,9 +124,17 @@ const getPostComments = async (req: PaginationRequest, res: Response) => {
     offset: req.offset,
     limit: req.limit,
   });
+
+  const local_comments = []; // only included local comments: no comments from remote nodes
+  for (let i = 0; i < comments.length; i++) {
+    if (comments[i].comment !== null) {
+      local_comments.push(comments[i]);
+    }
+  }
+
   res.send({
     type: 'comments',
-    comments: comments.map((comment) => serializeComment(comment, req)),
+    comments: local_comments.map((comment) => serializeComment(comment, req)),
   });
 };
 

--- a/src/server/src/controllers/follower.controllers.ts
+++ b/src/server/src/controllers/follower.controllers.ts
@@ -12,12 +12,12 @@ const addFollower = async (req: AuthenticatedRequest, res: Response) => {
     unauthorized(res);
     return;
   }
-  if (req.params.id === req.params.foreign_author_id) {
+  if (req.params.authorId === req.params.foreign_author_id) {
     res.status(400).send({ error: 'Cannot follow yourself' });
     return;
   }
 
-  const author = await Author.findByPk(req.params.id);
+  const author = await Author.findByPk(req.params.authorId);
   if (author === null) {
     res.status(404).send();
     return;
@@ -42,12 +42,12 @@ const addFollower = async (req: AuthenticatedRequest, res: Response) => {
 };
 
 const checkFollower = async (req: Request, res: Response) => {
-  if (req.params.id === req.params.foreign_author_id) {
+  if (req.params.authorId === req.params.foreign_author_id) {
     res.status(400).send({ error: 'Cannot check if following yourself' });
     return;
   }
 
-  const author = await Author.findByPk(req.params.id);
+  const author = await Author.findByPk(req.params.authorId);
   if (author === null) {
     res.status(404).send();
     return;
@@ -62,7 +62,7 @@ const checkFollower = async (req: Request, res: Response) => {
 const getAuthorFollowers = async (req: Request, res: Response) => {
   const followers = await Follower.findAll({
     where: {
-      authorId: req.params.id,
+      authorId: req.params.authorId,
     },
     attributes: [],
     include: {
@@ -80,7 +80,7 @@ const getAuthorFollowers = async (req: Request, res: Response) => {
 const getAuthorFollowings = async (req: Request, res: Response) => {
   const followings = await Follower.findAll({
     where: {
-      followerId: req.params.id,
+      followerId: req.params.authorId,
     },
     attributes: [],
     include: [
@@ -100,11 +100,11 @@ const getAuthorFollowings = async (req: Request, res: Response) => {
 };
 
 const removeFollower = async (req: Request, res: Response) => {
-  if (req.params.id === req.params.foreign_author_id) {
+  if (req.params.authorId === req.params.foreign_author_id) {
     res.status(400).send({ error: 'Cannot unfollow yourself' });
   }
 
-  const author = await Author.findByPk(req.params.id);
+  const author = await Author.findByPk(req.params.authorId);
   if (author === null) {
     res.status(404).send();
     return;

--- a/src/server/src/controllers/post.controllers.ts
+++ b/src/server/src/controllers/post.controllers.ts
@@ -172,6 +172,11 @@ const getAuthorPost = async (req: Request, res: Response) => {
     res.status(404).send();
     return;
   }
+  // to ensure that a remote post is not shown
+  if (post.content === null) {
+    res.status(404).send();
+    return;
+  }
   res.send(serializePost(post, req, comments));
 };
 
@@ -189,9 +194,16 @@ const getAuthorPosts = async (req: PaginationRequest, res: Response) => {
     offset: req.offset,
     limit: req.limit,
   });
+
+  const local_posts = []; // only included local posts: no posts from remote nodes
+  for (let i = 0; i < posts.length; i++) {
+    if (posts[i].content !== null) {
+      local_posts.push(posts[i]);
+    }
+  }
   res.send({
     type: 'posts',
-    items: posts.map((post) => serializePost(post, req)),
+    items: local_posts.map((post) => serializePost(post, req)),
   });
 };
 

--- a/src/server/src/controllers/post.controllers.ts
+++ b/src/server/src/controllers/post.controllers.ts
@@ -8,6 +8,7 @@ import { getHost } from '../utilities/host';
 import { pick } from '../utilities/pick';
 import { serializeAuthor } from './author.controllers';
 import { serializeComment } from './comment.controllers';
+import { FindOptions } from 'sequelize/types';
 
 const publicAttributes = [
   'id',
@@ -27,7 +28,7 @@ const publicAttributes = [
 export const serializePost = (
   post: Post,
   req: Request,
-  comments?: Comment[]
+  comments: Comment[]
 ): Record<string, unknown> => ({
   type: 'post',
   ...pick(post.toJSON(), publicAttributes),
@@ -38,26 +39,20 @@ export const serializePost = (
     post.id
   }/comments`,
   author: serializeAuthor(post.author, req),
-  ...(comments
-    ? {
-        commentsSrc: {
-          type: 'comments',
-          post: `${getHost(req)}/authors/${post.author.id}/posts/${post.id}`,
-          id: `${getHost(req)}/authors/${post.author.id}/posts/${
-            post.id
-          }/comments`,
-          page: 1,
-          size: comments.length,
-          comments: comments.map((comment) => serializeComment(comment, req)),
-        },
-      }
-    : {}),
+  commentsSrc: {
+    type: 'comments',
+    post: `${getHost(req)}/authors/${post.author.id}/posts/${post.id}`,
+    id: `${getHost(req)}/authors/${post.author.id}/posts/${post.id}/comments`,
+    page: 1,
+    size: comments.length,
+    comments: comments.map((comment) => serializeComment(comment, req)),
+  },
 });
 
 const createPost = async (req: AuthenticatedRequest, res: Response) => {
-  if (req.params.post_id) {
+  if (req.params.postId) {
     const post_exists = await Post.findOne({
-      where: { id: req.params.post_id },
+      where: { id: req.params.postId },
     });
     if (post_exists !== null) {
       res.status(400).send({ error: 'Post already exists' });
@@ -76,18 +71,14 @@ const createPost = async (req: AuthenticatedRequest, res: Response) => {
     visibility,
   } = req.body;
 
-  const author = await Author.findOne({
-    where: {
-      id: req.params.id,
-    },
-  });
+  const author = await Author.findByPk(req.params.authorId);
   if (author === null) {
     res.status(404).send();
     return;
   }
   try {
     const post = await Post.create({
-      ...(req.params.post_id && { id: req.params.post_id }),
+      ...(req.params.postId && { id: req.params.postId }),
       title: title,
       description: description,
       source: source,
@@ -113,7 +104,7 @@ const createPost = async (req: AuthenticatedRequest, res: Response) => {
 
 const deleteAuthorPost = async (req: AuthenticatedRequest, res: Response) => {
   const post = await Post.findOne({
-    where: { id: req.params.post_id, author_id: req.params.id },
+    where: { id: req.params.postId, author_id: req.params.authorId },
     include: { model: Author, as: 'author' },
   });
   if (post === null) {
@@ -130,80 +121,77 @@ const deleteAuthorPost = async (req: AuthenticatedRequest, res: Response) => {
   res.status(200).send();
 };
 
-const getAuthorPost = async (req: Request, res: Response) => {
-  const post = await Post.findOne({
-    attributes: publicAttributes,
-    where: {
-      id: req.params.post_id,
-      author_id: req.params.id,
-    },
-    include: {
+// FindOptions for querying posts on this node along with their author and comments information.
+const postFindOptions = (authorId?: string, postId?: string): FindOptions => ({
+  attributes: publicAttributes,
+  where: {
+    ...(authorId ? { author_id: authorId } : {}),
+    ...(postId ? { id: postId } : {}),
+    serviceUrl: null,
+  },
+  include: [
+    // Author of the post
+    {
       model: Author,
       attributes: ['id', 'displayName', 'github', 'profileImage'],
       as: 'author',
     },
-  });
-  const comments = await Comment.findAll({
-    attributes: ['comment', 'contentType', 'published', 'id'],
-    where: {
-      post_id: req.params.post_id,
+    // Comments on the post
+    {
+      model: Comment,
+      attributes: ['comment', 'contentType', 'published', 'id'],
+      as: 'comments',
+      include: [
+        // Author of the comments
+        {
+          model: Author,
+          attributes: ['id', 'displayName', 'github', 'profileImage'],
+          as: 'author',
+        },
+        // The post the comment is on (needed so that `comment.post` will work)
+        {
+          model: Post,
+          attributes: ['id'],
+          as: 'post',
+          include: [
+            {
+              model: Author,
+              attributes: ['id'],
+              as: 'author',
+            },
+          ],
+        },
+      ],
     },
-    include: [
-      {
-        model: Author,
-        attributes: ['id', 'displayName', 'github', 'profileImage'],
-        as: 'author',
-      },
-      {
-        model: Post,
-        attributes: ['id'],
-        as: 'post',
-        include: [
-          {
-            model: Author,
-            attributes: ['id'],
-            as: 'author',
-          },
-        ],
-      },
-    ],
-  });
+  ],
+});
+
+const getAuthorPost = async (req: Request, res: Response) => {
+  const post = await Post.findOne(
+    postFindOptions(req.params.authorId, req.params.postId)
+  );
+
   if (post === null) {
     res.status(404).send();
     return;
   }
-  // to ensure that a remote post is not shown
-  if (post.content === null) {
-    res.status(404).send();
-    return;
-  }
-  res.send(serializePost(post, req, comments));
+  res.send(serializePost(post, req, post.comments));
 };
 
 const getAuthorPosts = async (req: PaginationRequest, res: Response) => {
+  const author = await Author.findByPk(req.params.authorId);
+  if (author === null) {
+    res.status(404).send();
+    return;
+  }
   const posts = await Post.findAll({
-    attributes: publicAttributes,
-    where: {
-      author_id: req.params.id,
-    },
-    include: {
-      model: Author,
-      attributes: ['id', 'displayName', 'github', 'profileImage'],
-      as: 'author',
-    },
+    ...postFindOptions(req.params.authorId),
     offset: req.offset,
     limit: req.limit,
   });
-
-  const local_posts = []; // only included local posts: no posts from remote nodes
-  for (let i = 0; i < posts.length; i++) {
-    if (posts[i].content !== null) {
-      local_posts.push(posts[i]);
-    }
-  }
   res.send({
     type: 'posts',
-    items: local_posts.map((post) => serializePost(post, req)),
+    items: posts.map((post) => serializePost(post, req, post.comments)),
   });
 };
 
@@ -211,8 +199,8 @@ const getPostImage = async (req: Request, res: Response) => {
   const post = await Post.findOne({
     attributes: ['contentType', 'image'],
     where: {
-      id: req.params.post_id,
-      author_id: req.params.id,
+      id: req.params.postId,
+      author_id: req.params.authorId,
     },
   });
   if (post === null || !post.contentType.includes('image')) {
@@ -227,7 +215,7 @@ const getPostImage = async (req: Request, res: Response) => {
 
 const updateAuthorPost = async (req: AuthenticatedRequest, res: Response) => {
   const post = await Post.findOne({
-    where: { id: req.params.post_id, author_id: req.params.id },
+    where: { id: req.params.postId, author_id: req.params.authorId },
   });
   if (post === null) {
     res.status(404).send();

--- a/src/server/src/models/Author.ts
+++ b/src/server/src/models/Author.ts
@@ -42,16 +42,16 @@ Author.init(
     },
     email: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
       unique: true,
     },
     passwordHash: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     displayName: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     github: {
       type: DataTypes.STRING,
@@ -63,7 +63,7 @@ Author.init(
     },
     isAdmin: {
       type: DataTypes.BOOLEAN,
-      allowNull: false,
+      allowNull: true,
       defaultValue: false,
     },
     verified: {

--- a/src/server/src/models/Author.ts
+++ b/src/server/src/models/Author.ts
@@ -15,6 +15,7 @@ class Author extends Model {
   declare profileImage: string;
   declare isAdmin: boolean;
   declare verified: boolean;
+  declare serviceUrl: string;
   static Posts: HasMany;
   static Comments: HasMany;
   static Followers: HasMany;
@@ -70,6 +71,10 @@ Author.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    serviceUrl: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/src/server/src/models/Comment.ts
+++ b/src/server/src/models/Comment.ts
@@ -19,11 +19,11 @@ Comment.init(
   {
     comment: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     contentType: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
       defaultValue: 'text/plain',
       validate: {
         customValidator: (value) => {
@@ -36,7 +36,7 @@ Comment.init(
     },
     published: {
       type: DataTypes.DATE,
-      allowNull: false,
+      allowNull: true,
       defaultValue: DataTypes.NOW,
     },
     id: {

--- a/src/server/src/models/Comment.ts
+++ b/src/server/src/models/Comment.ts
@@ -5,25 +5,31 @@ import Author from './Author';
 import Post from './Post';
 
 class Comment extends Model {
+  declare id: typeof uuidv4;
+  declare comment: string;
+  declare contentType: 'text/markdown' | 'text/plain';
+  declare published: Date;
   static Author: BelongsTo;
   declare author: Author;
   static Post: BelongsTo;
   declare post: Post;
-  declare comment: string;
-  declare contentType: 'text/markdown' | 'text/plain';
-  declare published: Date;
-  declare id: typeof uuidv4;
 }
 
 Comment.init(
   {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      allowNull: false,
+      primaryKey: true,
+    },
     comment: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
     },
     contentType: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
       defaultValue: 'text/plain',
       validate: {
         customValidator: (value) => {
@@ -36,14 +42,8 @@ Comment.init(
     },
     published: {
       type: DataTypes.DATE,
-      allowNull: true,
-      defaultValue: DataTypes.NOW,
-    },
-    id: {
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4,
       allowNull: false,
-      primaryKey: true,
+      defaultValue: DataTypes.NOW,
     },
   },
   {

--- a/src/server/src/models/Post.ts
+++ b/src/server/src/models/Post.ts
@@ -40,23 +40,23 @@ Post.init(
     },
     title: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     source: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     origin: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     description: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     contentType: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
       defaultValue: 'text/plain',
       validate: {
         customValidator: (value) => {
@@ -83,21 +83,21 @@ Post.init(
     },
     categories: {
       type: DataTypes.ARRAY(DataTypes.STRING),
-      allowNull: false,
+      allowNull: true,
     },
     count: {
       type: DataTypes.INTEGER,
-      allowNull: false,
+      allowNull: true,
       defaultValue: 0,
     },
     published: {
       type: DataTypes.DATE,
-      allowNull: false,
+      allowNull: true,
       defaultValue: DataTypes.NOW,
     },
     visibility: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
       defaultValue: 'PUBLIC',
       validate: {
         customValidator: (value) => {
@@ -110,7 +110,7 @@ Post.init(
     },
     unlisted: {
       type: DataTypes.BOOLEAN,
-      allowNull: false,
+      allowNull: true,
       defaultValue: false,
     },
   },

--- a/src/server/src/models/Post.ts
+++ b/src/server/src/models/Post.ts
@@ -23,6 +23,7 @@ class Post extends Model {
   declare published: Date;
   declare visibility: 'PUBLIC' | 'FRIENDS';
   declare unlisted: boolean;
+  declare serviceUrl: string;
   static Author: BelongsTo;
   declare author: Author;
   static Comments: BelongsTo;
@@ -113,6 +114,10 @@ Post.init(
       allowNull: true,
       defaultValue: false,
     },
+    serviceUrl: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     sequelize: db,
@@ -121,7 +126,7 @@ Post.init(
   }
 );
 
-Post.Comments = Post.hasMany(Comment);
+Post.Comments = Post.hasMany(Comment, { as: 'comments' });
 Comment.Post = Comment.belongsTo(Post, { as: 'post' });
 
 export default Post;

--- a/src/server/src/routes/author.routes.ts
+++ b/src/server/src/routes/author.routes.ts
@@ -20,39 +20,39 @@ import {
 import { getAuthorFollowings } from '../controllers/follower.controllers';
 
 router.use(
-  '/:id/posts/:post_id/comments',
-  validate([param('id').isUUID(), param('post_id').isUUID()]),
+  '/:authorId/posts/:postId/comments',
+  validate([param('authorId').isUUID(), param('postId').isUUID()]),
   comments
 );
-router.use('/:id/posts', validate([param('id').isUUID()]), posts);
-router.use('/:id/followers', validate([param('id').isUUID()]), followers);
+router.use('/:authorId/posts', validate([param('authorId').isUUID()]), posts);
 router.use(
-  '/:id/following',
-  validate([param('id').isUUID()]),
+  '/:authorId/followers',
+  validate([param('authorId').isUUID()]),
+  followers
+);
+router.use(
+  '/:authorId/following',
+  validate([param('authorId').isUUID()]),
   getAuthorFollowings
 );
 
 router.get('/', paginate, getAllAuthors);
 router.get('/me', requiredLoggedIn, getCurrentAuthor);
 router.delete(
-  '/:id',
-  [adminOnly, validate([param('id').isUUID()])],
+  '/:authorId',
+  [adminOnly, validate([param('authorId').isUUID()])],
   deleteAuthor
 );
-router.get('/:id', validate([param('id').isUUID()]), getAuthor);
+router.get('/:authorId', validate([param('authorId').isUUID()]), getAuthor);
 router.post(
-  '/:id',
-  [
-    requiredLoggedIn,
-    validate([
-      param('id').isUUID(),
-      body('email').isEmail().optional(),
-      body('displayName').isString().optional(),
-      body('github').isURL().optional(),
-      body('profileImage').isURL().optional(),
-      body('verified').isBoolean().optional(),
-    ]),
-  ],
+  '/:authorId',
+  validate([
+    param('authorId').isUUID(),
+    body('email').isEmail().optional(),
+    body('displayName').isString().optional(),
+    body('github').isURL().optional(),
+    body('profileImage').isURL().optional(),
+  ]),
   updateProfile
 );
 

--- a/src/server/src/routes/comment.routes.ts
+++ b/src/server/src/routes/comment.routes.ts
@@ -19,13 +19,13 @@ router.post(
   '/',
   [
     requiredLoggedIn,
-    validate([
-      body('comment').isString(),
-      body('contentType').isIn([
-        'text/markdown',
-        'text/plain',
-      ]),
-    ]),
+    // validate([
+    //   body('comment').isString(),
+    //   body('contentType').isIn([
+    //     'text/markdown',
+    //     'text/plain',
+    //   ]),
+    // ]),
   ],
   createComment
 );

--- a/src/server/src/routes/comment.routes.ts
+++ b/src/server/src/routes/comment.routes.ts
@@ -8,24 +8,24 @@ import { validate } from '../middlewares/validator.middlewares';
 import { requiredLoggedIn } from '../middlewares/auth.middlewares';
 
 import {
-    createComment,
-    getPostComments,
+  createComment,
+  getPostComments,
 } from '../controllers/comment.controllers';
 
-
-router.get('/', [paginate, validate([param('post_id').isUUID()])], getPostComments);
+router.get(
+  '/',
+  [paginate, validate([param('postId').isUUID()])],
+  getPostComments
+);
 
 router.post(
   '/',
   [
     requiredLoggedIn,
-    // validate([
-    //   body('comment').isString(),
-    //   body('contentType').isIn([
-    //     'text/markdown',
-    //     'text/plain',
-    //   ]),
-    // ]),
+    validate([
+      body('comment').isString(),
+      body('contentType').isIn(['text/markdown', 'text/plain']),
+    ]),
   ],
   createComment
 );

--- a/src/server/src/routes/post.routes.ts
+++ b/src/server/src/routes/post.routes.ts
@@ -78,21 +78,21 @@ router.post(
   [
     requiredLoggedIn,
     multer().single('image'),
-    validate([
-      body('title').isString(),
-      body('description').isString(),
-      body('source').isURL(),
-      body('origin').isURL(),
-      body('contentType').isIn([
-        'text/markdown',
-        'text/plain',
-        'application/base64',
-        'image',
-      ]),
-      body('content').optional(),
-      body('categories.*').isString(),
-      body('visibility').isIn(['PUBLIC', 'FRIENDS']),
-    ]),
+    // validate([
+    //   body('title').isString(),
+    //   body('description').isString(),
+    //   body('source').isURL(),
+    //   body('origin').isURL(),
+    //   body('contentType').isIn([
+    //     'text/markdown',
+    //     'text/plain',
+    //     'application/base64',
+    //     'image',
+    //   ]),
+    //   body('content').optional(),
+    //   body('categories.*').isString(),
+    //   body('visibility').isIn(['PUBLIC', 'FRIENDS']),
+    // ]),
   ],
   createPost
 );

--- a/src/server/src/routes/post.routes.ts
+++ b/src/server/src/routes/post.routes.ts
@@ -16,19 +16,19 @@ import {
   updateAuthorPost,
 } from '../controllers/post.controllers';
 
-router.get('/:post_id', validate([param('post_id').isUUID()]), getAuthorPost);
+router.get('/:postId', validate([param('postId').isUUID()]), getAuthorPost);
 router.get(
-  '/:post_id/image',
-  validate([param('post_id').isUUID()]),
+  '/:postId/image',
+  validate([param('postId').isUUID()]),
   getPostImage
 );
 router.post(
-  '/:post_id',
+  '/:postId',
   [
     requiredLoggedIn,
     multer().single('image'),
     validate([
-      param('post_id').isUUID(),
+      param('postId').isUUID(),
       body('title').isString().optional(),
       body('description').isString().optional(),
       body('source').isURL().optional(),
@@ -44,17 +44,17 @@ router.post(
   updateAuthorPost
 );
 router.delete(
-  '/:post_id',
-  [requiredLoggedIn, validate([param('post_id').isUUID()])],
+  '/:postId',
+  [requiredLoggedIn, validate([param('postId').isUUID()])],
   deleteAuthorPost
 );
 router.put(
-  '/:post_id',
+  '/:postId',
   [
     requiredLoggedIn,
     multer().single('image'),
     validate([
-      param('post_id').isUUID(),
+      param('postId').isUUID(),
       body('title').isString(),
       body('description').isString(),
       body('source').isURL(),
@@ -78,21 +78,21 @@ router.post(
   [
     requiredLoggedIn,
     multer().single('image'),
-    // validate([
-    //   body('title').isString(),
-    //   body('description').isString(),
-    //   body('source').isURL(),
-    //   body('origin').isURL(),
-    //   body('contentType').isIn([
-    //     'text/markdown',
-    //     'text/plain',
-    //     'application/base64',
-    //     'image',
-    //   ]),
-    //   body('content').optional(),
-    //   body('categories.*').isString(),
-    //   body('visibility').isIn(['PUBLIC', 'FRIENDS']),
-    // ]),
+    validate([
+      body('title').isString(),
+      body('description').isString(),
+      body('source').isURL(),
+      body('origin').isURL(),
+      body('contentType').isIn([
+        'text/markdown',
+        'text/plain',
+        'application/base64',
+        'image',
+      ]),
+      body('content').optional(),
+      body('categories.*').isString(),
+      body('visibility').isIn(['PUBLIC', 'FRIENDS']),
+    ]),
   ],
   createPost
 );


### PR DESCRIPTION
- Post, Author, Comments all get `serviceUrl` field, which either is the service URL of a remote node, or null if it is local.
- All fields except `id` are optional for Post and Author so that they can be null for remote posts/authors.
- Fields are still required for Comment since comments are not editable, and thus their data can be stored locally even if they are remote comments.
- Updates endpoints to query only local data (`serviceUrl === null`)