### PR TITLE
Fix comments frontend API client

### DIFF
--- a/src/app/src/api/api.ts
+++ b/src/app/src/api/api.ts
@@ -9,7 +9,7 @@ import Comment, {
   CommentResponse,
   commentsFromResponse,
   CommentsResponse,
-  commentToRequest,
+  commentCreateToRequest,
 } from "./models/Comment";
 import Post, { postFromResponse, PostResponse } from "./models/Post";
 import InboxItem, {
@@ -453,25 +453,27 @@ const api = {
              * @returns a list of comments in the page
              */
             list: async (page?: number, size?: number): Promise<Comment[]> =>
-              (
-                await axios.get<{ items: CommentResponse[] }>(
-                  `/authors/${authorId}/posts/${postId}/comments`,
-                  {
-                    params: { page, size },
-                  }
-                )
-              ).data.items.map(commentFromResponse),
+              commentsFromResponse(
+                (
+                  await axios.get<CommentsResponse>(
+                    `/authors/${authorId}/posts/${postId}/comments`,
+                    { params: { page, size } }
+                  )
+                ).data
+              ),
 
             /**
              * Creates a comment on the post with a random ID.
              * @param comment the comment data
              * @returns TODO
              */
-            create: async (comment: Comment): Promise<unknown> =>
+            create: async (
+              comment: Pick<Comment, "comment" | "contentType">
+            ): Promise<unknown> =>
               (
                 await axios.post(
                   `/authors/${authorId}/posts/${postId}/comments`,
-                  commentToRequest(comment, baseUrl)
+                  commentCreateToRequest(comment, baseUrl)
                 )
               ).data,
 

--- a/src/app/src/api/models/Comment.ts
+++ b/src/app/src/api/models/Comment.ts
@@ -1,9 +1,4 @@
-import Author, {
-  authorFromResponse,
-  AuthorRequest,
-  AuthorResponse,
-  authorToRequest,
-} from "./Author";
+import Author, { authorFromResponse, AuthorResponse } from "./Author";
 
 export default interface Comment {
   type: "comment";
@@ -12,45 +7,46 @@ export default interface Comment {
   comment: string;
   contentType: string;
   published: string;
-  postId: string;
+  readonly postUrl: string; // URL of the API endpoint to get the post
+  readonly postServiceUrl: string; // service URL of the post
+  readonly postId: string; // id of the post the comment is on
 }
 
-export type CommentResponse = Omit<Comment, "id" | "author" | "postId"> & {
+export type CommentCreate = Pick<Comment, "comment" | "contentType">;
+
+export type CommentResponse = Pick<
+  Comment,
+  "type" | "id" | "comment" | "contentType" | "published"
+> & {
   id: string; // URL to the comment
   author: AuthorResponse;
 };
 
 export const commentFromResponse = (data: CommentResponse): Comment => {
-  const match = /\/posts\/([^/]+)\/comments\/([^/]+)\/?$/.exec(data.id);
+  const match = /^((.*?)\/posts\/([^/]+))\/comments\/([^/]+)\/?$/.exec(data.id);
   if (match === null) {
     throw new Error(`Invalid comment URL ${data.id}`);
   }
-  const postId = match[1];
-  const commentId = match[2];
+  const [postUrl, postServiceUrl, postId, commentId] = match.slice(1);
 
   return {
     ...data,
     author: authorFromResponse(data.author),
     id: commentId,
-    postId: postId,
+    postServiceUrl,
+    postId,
+    postUrl,
   };
 };
 
-export type CommentRequest = Omit<Comment, "id" | "author" | "postId"> & {
-  id: string; // URL to the comment
-  author: AuthorRequest;
-};
+export type CommentCreateRequest = CommentCreate;
 
-export const commentToRequest = (
-  comment: Comment,
+export const commentCreateToRequest = (
+  comment: CommentCreate,
   baseUrl: string
-): CommentRequest => {
-  return {
-    ...comment,
-    id: `${baseUrl}/authors/${comment.author.id}/posts/${comment.postId}/comments/${comment.id}`,
-    author: authorToRequest(comment.author, baseUrl),
-  };
-};
+): CommentCreateRequest => ({
+  ...comment,
+});
 
 export type CommentsResponse = {
   type: "comments";

--- a/src/app/src/components/MainComment.tsx
+++ b/src/app/src/components/MainComment.tsx
@@ -1,49 +1,66 @@
 import * as React from "react";
 import { Box, Card, CardContent, Typography } from "@mui/material";
-import Comment from "../api/models/Comment"
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
+import { useNavigate } from "react-router-dom";
+import Comment from "../api/models/Comment";
 
 export default function MainComment({
-    comment,
+  comment,
 }: {
-    comment: Comment,
+  comment: Comment;
 }): JSX.Element {
-    const handleClick = () =>{
-        window.open(`${comment.postId}`,"_blank");
-    }
+  const navigate = useNavigate();
 
-    return (
-    <Box style={{
-        width: '90%',
-        display: 'flex',}}
+  const handleClick = () => {
+    navigate(`/post/${comment.postId}?node=${comment.postServiceUrl}`);
+  };
+
+  return (
+    <Box
+      style={{
+        width: "90%",
+        display: "flex",
+      }}
     >
-        <Card 
-            variant="outlined"
-            sx={{
-            my:1,
-            boxShadow:2,
-            width:'90%',
-            ml: 13,
-            }}
+      <Card
+        variant="outlined"
+        sx={{
+          my: 1,
+          boxShadow: 2,
+          width: "90%",
+          ml: 13,
+        }}
+      >
+        <CardContent
+          sx={{
+            height: 15,
+            width: "90%",
+          }}
         >
-            <CardContent sx={{
-                height:15,
-                width: '90%',
-            }}>
-                <Box style={{
-                        display: 'flex',
-                        alignItems: 'center'}}
-                    sx={{
-                        width: '100%',
-                        height:'100%',
-                    }}>
-                    <ChatBubbleOutlineIcon/>
-                        <Typography noWrap ml={0.5}>
-                            {comment.author.displayName} commented on your post: <Box style={{textDecoration: 'underline', cursor:'pointer'}} component="span" onClick={handleClick}>{comment.postId}</Box>
-                        </Typography>
-                    </Box>
-            </CardContent>
-        </Card>
+          <Box
+            style={{
+              display: "flex",
+              alignItems: "center",
+            }}
+            sx={{
+              width: "100%",
+              height: "100%",
+            }}
+          >
+            <ChatBubbleOutlineIcon />
+            <Typography noWrap ml={0.5}>
+              {comment.author.displayName} commented on your post:{" "}
+              <Box
+                style={{ textDecoration: "underline", cursor: "pointer" }}
+                component="span"
+                onClick={handleClick}
+              >
+                {comment.comment}
+              </Box>
+            </Typography>
+          </Box>
+        </CardContent>
+      </Card>
     </Box>
   );
 };


### PR DESCRIPTION
This PR fixes the `create` and `list` comments methods in the frontend API client not working.