### PR TITLE
Browse all posts + AdminPost redirect

### DIFF
--- a/src/app/src/api/api.ts
+++ b/src/app/src/api/api.ts
@@ -114,6 +114,27 @@ const api = {
   },
 
   /**
+ * Actions on the posts.
+ */
+  posts: {
+    /**
+     * Fetches a paginated list of posts.
+     * @param page the page to return
+     * @param size the number of posts per page
+     * @returns a list of posts
+     */
+    list: async (page?: number, size?: number): Promise<Post[]> =>
+      (
+        await axios.get<{ items: PostResponse[] }>(
+          `/posts`,
+          {
+            params: { page, size },
+          }
+        )
+      ).data.items.map(postFromResponse)
+    },
+
+  /**
    * Actions on nodes.
    */
   nodes: {

--- a/src/app/src/components/AdminPostCard.tsx
+++ b/src/app/src/components/AdminPostCard.tsx
@@ -24,8 +24,13 @@ export default function AdminPostCard({
                         height:'100%',
                 }}>
                     
-                    <Typography sx={{ fontWeight: 'bold' }}>
-                            {post.id}
+                    <Typography 
+                        onClick={()=>window.open(`profile/${post.author.id}/post/${post.id}`,"_blank")} 
+                        noWrap={true} 
+                        style={{cursor:'pointer'}} 
+                        sx={{ fontWeight: 'bold', textDecoration:'underline' }}
+                        >
+                        {post.id}
                     </Typography>
 
                     <Typography>
@@ -35,7 +40,6 @@ export default function AdminPostCard({
                     <Typography>
                         {post.published}
                     </Typography>
-
                 </Box>
             </CardContent>
         </Card>

--- a/src/app/src/pages/Mainpage.tsx
+++ b/src/app/src/pages/Mainpage.tsx
@@ -10,7 +10,7 @@ import Backdrop from '@mui/material/Backdrop';
 import { CloseRounded } from '@mui/icons-material';
 import Fab from '@mui/material/Fab';
 import AddIcon from '@mui/icons-material/Add';
-import { List } from '@mui/material';
+import { Box, List, ButtonGroup, Button } from '@mui/material';
 
 // This is for all the stuff in the Main Page
 const MainPageContainer = styled.div`
@@ -38,9 +38,7 @@ interface Props {
 
 export default function Mainpage({ currentUser }: Props) {
   // For now, mainpage just shows your own posts
-  const [posts, setPosts] = useState<Post[] | undefined>(undefined);
   const [open, setOpen] = useState(false);
-  const [postsChanged, setpostsChanged] = useState(false);
 
   const handleClose = () => {
     setOpen(false);
@@ -50,6 +48,14 @@ export default function Mainpage({ currentUser }: Props) {
     setOpen(!open);
   };
 
+  const [inbox, setInbox] = useState<Post[] | undefined>(undefined);
+  const [inboxChanged, setInboxChanged] = useState(false);
+  const handleInboxChanged = () => {
+    setInboxChanged(!inboxChanged);
+  };
+
+  const [posts, setPosts] = useState<Post[] | undefined>(undefined);
+  const [postsChanged, setpostsChanged] = useState(false);
   const handlePostsChanged = () => {
     setpostsChanged(!postsChanged);
   };
@@ -58,8 +64,50 @@ export default function Mainpage({ currentUser }: Props) {
     api.authors
       .withId('' + currentUser?.id)
       .posts.list(1, 10)
+      .then((data) => setInbox(data));
+  }, [currentUser?.id, inboxChanged]);
+
+  useEffect(() => {
+    api
+      .posts
+      .list(1,10)
       .then((data) => setPosts(data));
-  }, [currentUser?.id, postsChanged]);
+  }, [postsChanged]);
+
+  // Sidebar Button group
+  const buttons = [
+    {id:0,title:'Inbox'},
+    {id:1,title:'Browse'}
+  ];
+
+  //Set which list to display
+  const [listDisplay, setListDisplay] = useState({id:0,title:'Inbox'});
+
+  const lists = [
+    inbox?.map((item)=>
+    (
+    <UserPost 
+      post={item} 
+      currentUser={currentUser} 
+      postAuthor={item.author} 
+      likes={0} 
+      handlePostsChanged={handleInboxChanged} 
+      key={item.id}
+    />
+    )),
+
+    posts?.map((post)=>
+    (
+    <UserPost 
+      post={post} 
+      currentUser={currentUser} 
+      postAuthor={post.author} 
+      likes={0} 
+      handlePostsChanged={handlePostsChanged} 
+      key={post.id}
+    />
+    )),
+  ]
 
   return (
     <MainPageContainer>
@@ -110,18 +158,48 @@ export default function Mainpage({ currentUser }: Props) {
         </Backdrop>
       ) : (
         <MainPageContentContainer>
-          <List style={{ maxHeight: '100%', overflow: 'auto' }} sx={{ width: '70%', ml: 5 }}>
-            {posts?.map((post) => (
-              <UserPost
-                post={post}
-                currentUser={currentUser}
-                postAuthor={currentUser}
-                likes={0}
-                handlePostsChanged={handlePostsChanged}
-                key={post.id}
-              />
-            ))}
-          </List>
+          <Box width='75%'>
+            <List style={{ maxHeight: '100%', overflow: 'auto' }} sx={{ width: '100%', ml: 5 }}>
+              <Box style={{
+                width: '90%',
+                display: 'flex',}}
+              >
+                <Box
+                    sx={{
+                    mb:5,
+                    width:'90%',
+                    ml: 13,
+                    }}
+                >
+                    <ButtonGroup
+                      orientation="horizontal"
+                      aria-label="horizontal contained button group"
+                      variant="contained"
+                      size="large"
+                      sx={{ 
+                        width:'100%',
+                      }}
+                    >
+                      {buttons.map((button) => (
+                        <Button 
+                          onClick={()=>setListDisplay(button)}
+                          key={button.id} 
+                          style={{
+                            justifyContent: 'center'
+                          }}
+                          sx={{
+                            justifyContent:"space-between", 
+                            width: '90%',
+                            
+                          }}
+                        > {button.title}</Button>
+                      ))}
+                    </ButtonGroup>
+                </Box>
+              </Box>
+              {lists[listDisplay.id]}
+            </List>
+            </Box>
           <GitContainer>
             <Github
               username={currentUser?.github ? `${currentUser.github.split('/').pop()}` : ''}

--- a/src/app/src/pages/__tests__/__snapshots__/Mainpage.test.tsx.snap
+++ b/src/app/src/pages/__tests__/__snapshots__/Mainpage.test.tsx.snap
@@ -49,15 +49,94 @@ exports[`Mainpage suite Renders correctly 1`] = `
   <div
     className="sc-bBHxTw eilNef"
   >
-    <ul
-      className="MuiList-root MuiList-padding css-xgw77h-MuiList-root"
-      style={
-        Object {
-          "maxHeight": "100%",
-          "overflow": "auto",
+    <div
+      className="MuiBox-root css-1hbj5v0"
+    >
+      <ul
+        className="MuiList-root MuiList-padding css-d05jsf-MuiList-root"
+        style={
+          Object {
+            "maxHeight": "100%",
+            "overflow": "auto",
+          }
         }
-      }
-    />
+      >
+        <div
+          className="MuiBox-root css-0"
+          style={
+            Object {
+              "display": "flex",
+              "width": "90%",
+            }
+          }
+        >
+          <div
+            className="MuiBox-root css-jfhg9a"
+          >
+            <div
+              aria-label="horizontal contained button group"
+              className="MuiButtonGroup-root MuiButtonGroup-contained css-6ekcsh-MuiButtonGroup-root"
+              role="group"
+            >
+              <button
+                className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButtonBase-root MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary css-j82eom-MuiButtonBase-root-MuiButton-root"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "justifyContent": "center",
+                  }
+                }
+                tabIndex={0}
+                type="button"
+              >
+                 
+                Inbox
+              </button>
+              <button
+                className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButtonBase-root MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary css-j82eom-MuiButtonBase-root-MuiButton-root"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "justifyContent": "center",
+                  }
+                }
+                tabIndex={0}
+                type="button"
+              >
+                 
+                Browse
+              </button>
+            </div>
+          </div>
+        </div>
+      </ul>
+    </div>
     <div
       className="sc-iwjdpV fZAKJX"
     >


### PR DESCRIPTION
Can now tab between your inbox (currently just your own posts) and all public posts on the server.
Admin posts now redirect to comments page when id clicked.

![Screen Shot 2022-04-03 at 11 12 24 PM](https://user-images.githubusercontent.com/55111012/161478087-86272095-266d-4b55-9a1a-4f5935612666.png)

<img width="1272" alt="Screen Shot 2022-04-03 at 11 11 32 PM" src="https://user-images.githubusercontent.com/55111012/161478009-16fa819b-f39e-4125-ab19-958edccaa938.png">
